### PR TITLE
Add local herdr plugins: Claude session fork + exec-based hunk forks

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -164,6 +164,16 @@ key = "prefix+|"
 type = "plugin_action"
 command = "hunk.diff.branch-split"
 
+[[keys.command]]
+key = "prefix+ctrl+right"
+type = "plugin_action"
+command = "local.claude-fork.right"
+
+[[keys.command]]
+key = "prefix+ctrl+down"
+type = "plugin_action"
+command = "local.claude-fork.down"
+
 
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -160,7 +160,7 @@ type = "plugin_action"
 command = "local.hunk-gh-diff.pr-split"
 
 [[keys.command]]
-key = "prefix+|"
+key = "prefix+alt+d"
 type = "plugin_action"
 command = "local.hunk-diff.branch-split"
 

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -157,12 +157,12 @@ command = "lazygit"
 [[keys.command]]
 key = "prefix+alt+p" # moved off prefix+p so previous_tab can use it
 type = "plugin_action"
-command = "hunk.gh-diff.pr-split"
+command = "local.hunk-gh-diff.pr-split"
 
 [[keys.command]]
 key = "prefix+|"
 type = "plugin_action"
-command = "hunk.diff.branch-split"
+command = "local.hunk-diff.branch-split"
 
 [[keys.command]]
 key = "prefix+ctrl+right"

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fork the Claude Code session running in the current pane into a new split
 # pane, carrying over its conversation history via `claude --fork-session`.
-# Approach adapted from https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
+# Original approach: https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
 set -euo pipefail
 
 direction="${1:-right}"

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Fork the Claude Code session running in the current pane into a new split
 # pane, carrying over its conversation history via `claude --fork-session`.
-# Original approach: https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
+# Credit to miyagawa for the original approach:
+# https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
 set -euo pipefail
 
 direction="${1:-right}"

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fork the Claude Code session running in the current pane into a new split
+# pane, carrying over its conversation history via `claude --fork-session`.
+# Approach adapted from https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
+set -euo pipefail
+
+direction="${1:-right}"
+case "$direction" in
+  right|down) ;;
+  *)
+    echo "usage: fork.sh [right|down]" >&2
+    exit 1
+    ;;
+esac
+
+pane_id="${HERDR_PANE_ID:?HERDR_PANE_ID not set — run this action from a pane context}"
+
+pane_json=$(herdr pane get "$pane_id")
+session_id=$(jq -r '.result.pane.agent_session.value // empty' <<<"$pane_json")
+cwd=$(jq -r '.result.pane.cwd' <<<"$pane_json")
+
+if [ -z "$session_id" ]; then
+  echo "No Claude Code session detected on pane $pane_id" >&2
+  exit 1
+fi
+
+split_json=$(herdr pane split --pane "$pane_id" --direction "$direction" --cwd "$cwd" --focus)
+new_pane_id=$(jq -r '.result.pane.pane_id' <<<"$split_json")
+
+herdr pane run "$new_pane_id" exec claude --resume "$session_id" --fork-session

--- a/.config/herdr/plugins/claude-fork/herdr-plugin.toml
+++ b/.config/herdr/plugins/claude-fork/herdr-plugin.toml
@@ -1,0 +1,18 @@
+id = "local.claude-fork"
+name = "Claude Fork"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "Fork the current Claude Code session's conversation history into a new pane"
+platforms = ["macos", "linux"]
+
+[[actions]]
+id = "right"
+title = "Fork Claude session (right)"
+contexts = ["pane"]
+command = ["bash", "fork.sh", "right"]
+
+[[actions]]
+id = "down"
+title = "Fork Claude session (down)"
+contexts = ["pane"]
+command = ["bash", "fork.sh", "down"]

--- a/.config/herdr/plugins/hunk-diff/herdr-plugin.toml
+++ b/.config/herdr/plugins/hunk-diff/herdr-plugin.toml
@@ -1,4 +1,4 @@
-id = "hunk.diff"
+id = "local.hunk-diff"
 name = "Hunk Diff"
 version = "0.1.0"
 min_herdr_version = "0.7.0"

--- a/.config/herdr/plugins/hunk-diff/herdr-plugin.toml
+++ b/.config/herdr/plugins/hunk-diff/herdr-plugin.toml
@@ -1,0 +1,42 @@
+id = "hunk.diff"
+name = "Hunk Diff"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "Open Hunk diffs from Herdr in a split pane or tab, execing directly into the target pane"
+platforms = ["macos", "linux"]
+
+[[actions]]
+id = "worktree-split"
+title = "Hunk worktree diff in split"
+contexts = ["pane", "workspace"]
+command = ["bash", "hunk-launch.sh", "worktree", "split"]
+
+[[actions]]
+id = "worktree-tab"
+title = "Hunk worktree diff in tab"
+contexts = ["pane", "workspace"]
+command = ["bash", "hunk-launch.sh", "worktree", "tab"]
+
+[[actions]]
+id = "staged-split"
+title = "Hunk staged diff in split"
+contexts = ["pane", "workspace"]
+command = ["bash", "hunk-launch.sh", "staged", "split"]
+
+[[actions]]
+id = "staged-tab"
+title = "Hunk staged diff in tab"
+contexts = ["pane", "workspace"]
+command = ["bash", "hunk-launch.sh", "staged", "tab"]
+
+[[actions]]
+id = "branch-split"
+title = "Hunk branch diff in split"
+contexts = ["pane", "workspace"]
+command = ["bash", "hunk-launch.sh", "branch", "split"]
+
+[[actions]]
+id = "branch-tab"
+title = "Hunk branch diff in tab"
+contexts = ["pane", "workspace"]
+command = ["bash", "hunk-launch.sh", "branch", "tab"]

--- a/.config/herdr/plugins/hunk-diff/hunk-launch.sh
+++ b/.config/herdr/plugins/hunk-diff/hunk-launch.sh
@@ -2,7 +2,8 @@
 # Local exec-based replacement for edmundmiller/herdr-plugin-hunk: launches
 # `hunk` directly in the target pane (via `exec`) instead of leaving a shell
 # wrapping it, same trick as ../claude-fork/fork.sh.
-# Original approach: https://github.com/edmundmiller/herdr-plugin-hunk
+# Credit to edmundmiller for the original approach:
+# https://github.com/edmundmiller/herdr-plugin-hunk
 set -euo pipefail
 
 mode="${1:?usage: hunk-launch.sh <worktree|staged|branch> <split|tab>}"

--- a/.config/herdr/plugins/hunk-diff/hunk-launch.sh
+++ b/.config/herdr/plugins/hunk-diff/hunk-launch.sh
@@ -10,7 +10,8 @@ target="${2:?usage: hunk-launch.sh <worktree|staged|branch> <split|tab>}"
 case "$mode" in worktree|staged|branch) ;; *) echo "invalid mode: $mode" >&2; exit 1 ;; esac
 case "$target" in split|tab) ;; *) echo "invalid target: $target" >&2; exit 1 ;; esac
 
-ctx="${HERDR_PLUGIN_CONTEXT_JSON:-{}}"
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
+[ -n "$ctx" ] || ctx='{}'
 workspace_id=$(jq -r '.workspace_id // empty' <<<"$ctx")
 workspace_id="${workspace_id:-${HERDR_WORKSPACE_ID:?missing Herdr workspace id}}"
 pane_id=$(jq -r '.focused_pane_id // empty' <<<"$ctx")

--- a/.config/herdr/plugins/hunk-diff/hunk-launch.sh
+++ b/.config/herdr/plugins/hunk-diff/hunk-launch.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Local exec-based replacement for edmundmiller/herdr-plugin-hunk: launches
+# `hunk` directly in the target pane (via `exec`) instead of leaving a shell
+# wrapping it, same trick as ../claude-fork/fork.sh.
+set -euo pipefail
+
+mode="${1:?usage: hunk-launch.sh <worktree|staged|branch> <split|tab>}"
+target="${2:?usage: hunk-launch.sh <worktree|staged|branch> <split|tab>}"
+
+case "$mode" in worktree|staged|branch) ;; *) echo "invalid mode: $mode" >&2; exit 1 ;; esac
+case "$target" in split|tab) ;; *) echo "invalid target: $target" >&2; exit 1 ;; esac
+
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-{}}"
+workspace_id=$(jq -r '.workspace_id // empty' <<<"$ctx")
+workspace_id="${workspace_id:-${HERDR_WORKSPACE_ID:?missing Herdr workspace id}}"
+pane_id=$(jq -r '.focused_pane_id // empty' <<<"$ctx")
+pane_id="${pane_id:-${HERDR_PANE_ID:-}}"
+cwd=$(jq -r '.focused_pane_cwd // .workspace_cwd // empty' <<<"$ctx")
+cwd="${cwd:-$PWD}"
+
+case "$mode" in
+  staged)
+    diff_args=(diff --staged)
+    ;;
+  branch)
+    branch=$(git -C "$cwd" branch --show-current || true)
+    branch="${branch:-HEAD}"
+    upstream=$(git -C "$cwd" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+    if [ -z "$upstream" ]; then
+      for candidate in origin/main origin/master main master; do
+        if git -C "$cwd" rev-parse --verify "$candidate" >/dev/null 2>&1; then
+          upstream="$candidate"
+          break
+        fi
+      done
+      upstream="${upstream:-origin/main}"
+    fi
+    diff_args=(diff "${upstream}..${branch}")
+    ;;
+  *)
+    diff_args=(diff)
+    ;;
+esac
+
+theme_args=(--no-transparent-bg)
+if [ -n "${HUNK_THEME:-}" ]; then
+  theme_args=(--theme "$HUNK_THEME" --no-transparent-bg)
+fi
+
+if command -v hunk >/dev/null 2>&1; then
+  hunk_cmd=(hunk "${diff_args[@]}" "${theme_args[@]}")
+else
+  hunk_cmd=(bunx hunkdiff "${diff_args[@]}" "${theme_args[@]}")
+fi
+
+if [ "$target" = "tab" ]; then
+  split_json=$(herdr tab create --workspace "$workspace_id" --cwd "$cwd" --label hunk --focus)
+  hunk_pane=$(jq -r '.result.root_pane.pane_id' <<<"$split_json")
+else
+  : "${pane_id:?missing focused Herdr pane id}"
+  split_json=$(herdr pane split "$pane_id" --direction right --cwd "$cwd" --focus)
+  hunk_pane=$(jq -r '.result.pane.pane_id' <<<"$split_json")
+fi
+
+herdr pane rename "$hunk_pane" hunk
+herdr pane run "$hunk_pane" exec "${hunk_cmd[@]}"

--- a/.config/herdr/plugins/hunk-diff/hunk-launch.sh
+++ b/.config/herdr/plugins/hunk-diff/hunk-launch.sh
@@ -2,6 +2,7 @@
 # Local exec-based replacement for edmundmiller/herdr-plugin-hunk: launches
 # `hunk` directly in the target pane (via `exec`) instead of leaving a shell
 # wrapping it, same trick as ../claude-fork/fork.sh.
+# Original approach: https://github.com/edmundmiller/herdr-plugin-hunk
 set -euo pipefail
 
 mode="${1:?usage: hunk-launch.sh <worktree|staged|branch> <split|tab>}"

--- a/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
+++ b/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Local exec-based replacement for Allianaab2m/herdr-hunk-gh-diff: launches
+# `hunk` directly in the target pane (via `exec`) instead of leaving a shell
+# wrapping it, same trick as ../claude-fork/fork.sh.
+set -euo pipefail
+
+target="${1:?usage: gh-diff-launch.sh <split|tab>}"
+case "$target" in split|tab) ;; *) echo "invalid target: $target" >&2; exit 1 ;; esac
+
+command -v gh >/dev/null 2>&1 || { echo "gh (GitHub CLI) is required but was not found on PATH." >&2; exit 1; }
+
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-{}}"
+workspace_id=$(jq -r '.workspace_id // empty' <<<"$ctx")
+workspace_id="${workspace_id:-${HERDR_WORKSPACE_ID:?missing Herdr workspace id}}"
+pane_id=$(jq -r '.focused_pane_id // empty' <<<"$ctx")
+pane_id="${pane_id:-${HERDR_PANE_ID:-}}"
+cwd=$(jq -r '.focused_pane_cwd // .workspace_cwd // empty' <<<"$ctx")
+cwd="${cwd:-$PWD}"
+
+branch=$(git -C "$cwd" branch --show-current || true)
+
+if [ -n "$branch" ]; then
+  pr_json=$(gh pr view "$branch" --json baseRefName,number,url 2>/dev/null) || pr_json=""
+else
+  pr_json=$(gh pr view --json baseRefName,number,url 2>/dev/null) || pr_json=""
+fi
+if [ -z "$pr_json" ]; then
+  echo "No GitHub PR found${branch:+ for branch '$branch'}." >&2
+  exit 1
+fi
+
+base_name=$(jq -r '.baseRefName // empty' <<<"$pr_json")
+pr_number=$(jq -r '.number // empty' <<<"$pr_json")
+[ -n "$base_name" ] || { echo "The GitHub PR did not report a base branch." >&2; exit 1; }
+
+base_ref="$base_name"
+if git -C "$cwd" rev-parse --verify "origin/$base_name" >/dev/null 2>&1; then
+  base_ref="origin/$base_name"
+elif ! git -C "$cwd" rev-parse --verify "$base_name" >/dev/null 2>&1; then
+  git -C "$cwd" fetch origin "$base_name" >/dev/null 2>&1 || true
+  git -C "$cwd" rev-parse --verify "origin/$base_name" >/dev/null 2>&1 && base_ref="origin/$base_name"
+fi
+
+head="${branch:-HEAD}"
+separator="..."
+[ -n "${HUNK_GH_DIFF_TWO_DOT:-}" ] && separator=".."
+range="${base_ref}${separator}${head}"
+
+theme_args=(--no-transparent-bg)
+[ -n "${HUNK_THEME:-}" ] && theme_args=(--theme "$HUNK_THEME" --no-transparent-bg)
+
+if command -v hunk >/dev/null 2>&1; then
+  hunk_cmd=(hunk diff "$range" "${theme_args[@]}")
+else
+  hunk_cmd=(bunx hunkdiff diff "$range" "${theme_args[@]}")
+fi
+
+label="hunk"
+[ -n "$pr_number" ] && label="hunk PR#$pr_number"
+
+if [ "$target" = "tab" ]; then
+  split_json=$(herdr tab create --workspace "$workspace_id" --cwd "$cwd" --label "$label" --focus)
+  hunk_pane=$(jq -r '.result.root_pane.pane_id' <<<"$split_json")
+else
+  : "${pane_id:?missing focused Herdr pane id}"
+  split_json=$(herdr pane split "$pane_id" --direction right --cwd "$cwd" --focus)
+  hunk_pane=$(jq -r '.result.pane.pane_id' <<<"$split_json")
+fi
+
+herdr pane rename "$hunk_pane" "$label"
+herdr pane run "$hunk_pane" exec "${hunk_cmd[@]}"

--- a/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
+++ b/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
@@ -2,7 +2,8 @@
 # Local exec-based replacement for Allianaab2m/herdr-hunk-gh-diff: launches
 # `hunk` directly in the target pane (via `exec`) instead of leaving a shell
 # wrapping it, same trick as ../claude-fork/fork.sh.
-# Original approach: https://github.com/Allianaab2m/herdr-hunk-gh-diff
+# Credit to Allianaab2m for the original approach:
+# https://github.com/Allianaab2m/herdr-hunk-gh-diff
 set -euo pipefail
 
 target="${1:?usage: gh-diff-launch.sh <split|tab>}"

--- a/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
+++ b/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
@@ -2,6 +2,7 @@
 # Local exec-based replacement for Allianaab2m/herdr-hunk-gh-diff: launches
 # `hunk` directly in the target pane (via `exec`) instead of leaving a shell
 # wrapping it, same trick as ../claude-fork/fork.sh.
+# Original approach: https://github.com/Allianaab2m/herdr-hunk-gh-diff
 set -euo pipefail
 
 target="${1:?usage: gh-diff-launch.sh <split|tab>}"

--- a/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
+++ b/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
@@ -9,7 +9,8 @@ case "$target" in split|tab) ;; *) echo "invalid target: $target" >&2; exit 1 ;;
 
 command -v gh >/dev/null 2>&1 || { echo "gh (GitHub CLI) is required but was not found on PATH." >&2; exit 1; }
 
-ctx="${HERDR_PLUGIN_CONTEXT_JSON:-{}}"
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
+[ -n "$ctx" ] || ctx='{}'
 workspace_id=$(jq -r '.workspace_id // empty' <<<"$ctx")
 workspace_id="${workspace_id:-${HERDR_WORKSPACE_ID:?missing Herdr workspace id}}"
 pane_id=$(jq -r '.focused_pane_id // empty' <<<"$ctx")

--- a/.config/herdr/plugins/hunk-gh-diff/herdr-plugin.toml
+++ b/.config/herdr/plugins/hunk-gh-diff/herdr-plugin.toml
@@ -1,0 +1,18 @@
+id = "hunk.gh-diff"
+name = "Hunk GitHub PR Diff"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "Open a Hunk diff between the current branch and its GitHub PR's base branch, execing directly into the target pane"
+platforms = ["macos", "linux"]
+
+[[actions]]
+id = "pr-split"
+title = "Hunk PR diff in split"
+contexts = ["pane", "workspace"]
+command = ["bash", "gh-diff-launch.sh", "split"]
+
+[[actions]]
+id = "pr-tab"
+title = "Hunk PR diff in tab"
+contexts = ["pane", "workspace"]
+command = ["bash", "gh-diff-launch.sh", "tab"]

--- a/.config/herdr/plugins/hunk-gh-diff/herdr-plugin.toml
+++ b/.config/herdr/plugins/hunk-gh-diff/herdr-plugin.toml
@@ -1,4 +1,4 @@
-id = "hunk.gh-diff"
+id = "local.hunk-gh-diff"
 name = "Hunk GitHub PR Diff"
 version = "0.1.0"
 min_herdr_version = "0.7.0"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@
 
 	herdr plugin install edmundmiller/herdr-plugin-hunk -y
 	herdr plugin install Allianaab2m/herdr-hunk-gh-diff -y
+	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/claude-fork

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@
 	mkdir -p ~/.config/hunk
 	ln -sf ~/src/github.com/motchang/dotfiles/.config/hunk/config.toml ~/.config/hunk/config.toml
 
-	herdr plugin install edmundmiller/herdr-plugin-hunk -y
-	herdr plugin install Allianaab2m/herdr-hunk-gh-diff -y
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/claude-fork
+	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-diff
+	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-gh-diff


### PR DESCRIPTION
## Summary
- New `local.claude-fork` plugin: forks the Claude Code session in the focused pane into a new split pane, carrying over conversation history via `claude --resume --fork-session` (approach credited to miyagawa's gist)
- Replaced the GitHub-installed `hunk.diff` / `hunk.gh-diff` plugins with independent local forks (`local.hunk-diff`, `local.hunk-gh-diff`) that `exec` directly into the target pane instead of leaving a shell wrapping the process, crediting the original authors (edmundmiller, Allianaab2m)
- Fixed a macOS `/bin/bash` (3.2) parsing bug in the hunk forks where `${VAR:-{}}` leaked a stray `}` and broke every real invocation
- Rebound keys for reliability/mnemonics: `prefix+ctrl+right`/`down` for the Claude fork, `prefix+alt+p`/`prefix+alt+d` for the PR/branch hunk diffs
- Updated README install steps to `herdr plugin link` the three local plugins

## Test plan
- [x] `herdr config check` passes
- [x] Each plugin action tested end-to-end via direct invocation (`herdr pane process-info` confirmed `exec` replaces the pane's shell process for both hunk forks)
- [x] `local.hunk-gh-diff` tested against a real open PR on this repo
- [x] Re-tested after the bash 3.2 bugfix with a realistic `HERDR_PLUGIN_CONTEXT_JSON` payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)