### PR TITLE
Fix repo/base resolution bugs in local hunk plugin forks

### DIFF
--- a/.config/herdr/plugins/hunk-diff/hunk-launch.sh
+++ b/.config/herdr/plugins/hunk-diff/hunk-launch.sh
@@ -38,7 +38,7 @@ case "$mode" in
       fi
     done
     base="${base:-origin/main}"
-    diff_args=(diff "${base}..${branch}")
+    diff_args=(diff "${base}...${branch}")
     ;;
   *)
     diff_args=(diff)

--- a/.config/herdr/plugins/hunk-diff/hunk-launch.sh
+++ b/.config/herdr/plugins/hunk-diff/hunk-launch.sh
@@ -28,17 +28,17 @@ case "$mode" in
   branch)
     branch=$(git -C "$cwd" branch --show-current || true)
     branch="${branch:-HEAD}"
-    upstream=$(git -C "$cwd" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
-    if [ -z "$upstream" ]; then
-      for candidate in origin/main origin/master main master; do
-        if git -C "$cwd" rev-parse --verify "$candidate" >/dev/null 2>&1; then
-          upstream="$candidate"
-          break
-        fi
-      done
-      upstream="${upstream:-origin/main}"
-    fi
-    diff_args=(diff "${upstream}..${branch}")
+    remote_head=$(git -C "$cwd" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)
+    base=""
+    for candidate in "$remote_head" origin/main origin/master main master; do
+      [ -n "$candidate" ] || continue
+      if git -C "$cwd" rev-parse --verify "$candidate" >/dev/null 2>&1; then
+        base="$candidate"
+        break
+      fi
+    done
+    base="${base:-origin/main}"
+    diff_args=(diff "${base}..${branch}")
     ;;
   *)
     diff_args=(diff)

--- a/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
+++ b/.config/herdr/plugins/hunk-gh-diff/gh-diff-launch.sh
@@ -23,9 +23,9 @@ cwd="${cwd:-$PWD}"
 branch=$(git -C "$cwd" branch --show-current || true)
 
 if [ -n "$branch" ]; then
-  pr_json=$(gh pr view "$branch" --json baseRefName,number,url 2>/dev/null) || pr_json=""
+  pr_json=$(cd "$cwd" && gh pr view "$branch" --json baseRefName,number,url 2>/dev/null) || pr_json=""
 else
-  pr_json=$(gh pr view --json baseRefName,number,url 2>/dev/null) || pr_json=""
+  pr_json=$(cd "$cwd" && gh pr view --json baseRefName,number,url 2>/dev/null) || pr_json=""
 fi
 if [ -z "$pr_json" ]; then
   echo "No GitHub PR found${branch:+ for branch '$branch'}." >&2


### PR DESCRIPTION
## Summary
- Addresses two P1 findings from Codex's automated review on #34 (already merged) in the local exec-based hunk plugin forks
- `hunk-gh-diff`: `gh pr view` now runs from the focused pane's `$cwd` instead of the plugin's own directory, so it resolves the correct PR/repo when invoked from a repo other than this dotfiles checkout
- `hunk-diff` (branch mode): stopped using `@{upstream}` to find the diff base — for a branch pushed with `git push -u origin feature`, upstream is `origin/feature` (itself), not the base branch, which produced an empty or unpushed-commits-only diff. Base is now determined independently via `origin/HEAD`, falling back through `origin/main`/`origin/master`/`main`/`master`

## Test plan
- [x] `bash -n` on both scripts under both `/bin/bash` (macOS 3.2) and the default bash
- [x] Verified `git symbolic-ref -q --short refs/remotes/origin/HEAD` resolves to `origin/master` in this repo, confirming the new base-detection path

🤖 Generated with [Claude Code](https://claude.com/claude-code)