### PR TITLE
Add mdpreview, a local markdown preview in a herdr-browser pane

### DIFF
--- a/.config/herdr/bin/herdr-browser
+++ b/.config/herdr/bin/herdr-browser
@@ -1,0 +1,18 @@
+#!/bin/sh
+# herdr-browser plugin CLI wrapper.
+# Resolves the installed plugin root, then forwards args to its cli.ts.
+#   herdr-browser open http://localhost:3000
+#   herdr-browser text
+#   herdr-browser selector-click 'button[type=submit]'
+#   herdr-browser help
+set -e
+
+root=$(herdr plugin list --plugin official.browser --json \
+  | jq -r '.result.plugins[0].plugin_root // empty')
+
+if [ -z "$root" ]; then
+  echo "herdr-browser: official.browser plugin not found (herdr plugin install ogulcancelik/herdr-browser)" >&2
+  exit 1
+fi
+
+exec bun run "$root/src/cli.ts" "$@"

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -58,7 +58,24 @@ jq -n --arg path "$file" '{path: $path}' \
 
 # A view with no pane behind it renders into a Chrome nobody can see, so open a
 # pane when there is none instead of navigating a headless view.
-if [ "$(herdr-browser views | jq '.views | length')" -eq 0 ]; then
+# The count has to be a real number before it reaches `-eq`: an empty or
+# non-numeric value makes that test a shell error, and since it sits in an `if`
+# condition `set -e` lets it through as merely false - which takes the
+# headless-navigate path this check exists to avoid. Report it instead.
+# The `type == "array"` guard is what makes that work: `null | length` is 0, so
+# any shape without a top-level .views array (a wrapped {result: {views: ...}},
+# an error object) would otherwise read as "no views" and stack up a fresh pane
+# on every run. Emitting nothing turns an unrecognized shape into "unknown".
+views=$(herdr-browser views \
+  | jq '.views | if type == "array" then length else empty end' 2>/dev/null) || views=
+case "$views" in
+  '' | *[!0-9]*)
+    echo "mdpreview: could not read the herdr-browser view count - is herdr-browser on PATH and working?" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$views" -eq 0 ]; then
   exec herdr plugin pane open \
     --plugin official.browser --entrypoint browser \
     --placement split --direction right \

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -43,9 +43,13 @@ fi
 if ! curl -fsS -m 1 "${base}/health" >/dev/null 2>&1; then
   # --retry-connrefused lets the first request wait out the server's startup.
   nohup bun run "${root}/server.ts" >>"${TMPDIR:-/tmp}/mdpreview.log" 2>&1 &
-  # Each connection-refused retry would otherwise print its own error.
-  curl -fsS --retry 30 --retry-delay 0 --retry-connrefused -m 10 \
-    "${base}/health" >/dev/null 2>/dev/null
+  # Each connection-refused retry would otherwise print its own error, so the
+  # retry output is dropped and the final failure is reported here instead.
+  if ! curl -fsS --retry 30 --retry-delay 0 --retry-connrefused -m 10 \
+      "${base}/health" >/dev/null 2>/dev/null; then
+    echo "mdpreview: server did not start on ${base} - see ${TMPDIR:-/tmp}/mdpreview.log" >&2
+    exit 1
+  fi
 fi
 
 jq -n --arg path "$file" '{path: $path}' \

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Preview a markdown file (mermaid included) in a herdr-browser pane.
+#   mdpreview README.md
+#   mdpreview --stop
+#
+# Starts a local render server on first use and reuses it afterwards; the page
+# live-reloads when the file changes.
+set -e
+
+port=${MDPREVIEW_PORT:-43128}
+base="http://127.0.0.1:${port}"
+
+self=$0
+# Follow the ~/bin symlink back to the copy inside the dotfiles repo.
+if command -v readlink >/dev/null 2>&1 && readlink -f "$self" >/dev/null 2>&1; then
+  self=$(readlink -f "$self")
+fi
+root=$(CDPATH= cd -- "$(dirname -- "$self")/../mdpreview" && pwd)
+
+if [ "$1" = "--stop" ]; then
+  pkill -f "bun run ${root}/server.ts" 2>/dev/null || true
+  pkill -f "bun ${root}/server.ts" 2>/dev/null || true
+  echo "mdpreview: stopped"
+  exit 0
+fi
+
+if [ -z "$1" ]; then
+  echo "usage: mdpreview <file.md> | --stop" >&2
+  exit 1
+fi
+
+if [ ! -d "${root}/node_modules" ]; then
+  echo "mdpreview: dependencies missing - run 'bun install' in ${root}" >&2
+  exit 1
+fi
+
+file=$(CDPATH= cd -- "$(dirname -- "$1")" && pwd)/$(basename -- "$1")
+if [ ! -f "$file" ]; then
+  echo "mdpreview: no such file: $file" >&2
+  exit 1
+fi
+
+if ! curl -fsS -m 1 "${base}/health" >/dev/null 2>&1; then
+  # --retry-connrefused lets the first request wait out the server's startup.
+  nohup bun run "${root}/server.ts" >>"${TMPDIR:-/tmp}/mdpreview.log" 2>&1 &
+  # Each connection-refused retry would otherwise print its own error.
+  curl -fsS --retry 30 --retry-delay 0 --retry-connrefused -m 10 \
+    "${base}/health" >/dev/null 2>/dev/null
+fi
+
+jq -n --arg path "$file" '{path: $path}' \
+  | curl -fsS -X POST -H 'content-type: application/json' --data @- "${base}/open" \
+  >/dev/null
+
+# A view with no pane behind it renders into a Chrome nobody can see, so open a
+# pane when there is none instead of navigating a headless view.
+if [ "$(herdr-browser views | jq '.views | length')" -eq 0 ]; then
+  exec herdr plugin pane open \
+    --plugin official.browser --entrypoint browser \
+    --placement split --direction right \
+    --env "HERDR_BROWSER_INITIAL_URL=${base}/" --focus
+fi
+
+exec herdr-browser open "${base}/"

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -165,6 +165,14 @@ type = "plugin_action"
 command = "local.hunk-diff.branch-split"
 
 [[keys.command]]
+# prefix+b is already goto (see the goto binding above), so the browser pane
+# takes prefix+alt+b, matching the other prefix+alt+* plugin bindings here.
+key = "prefix+alt+b"
+type = "shell"
+command = '"${HERDR_BIN_PATH}" plugin pane open --plugin official.browser --entrypoint browser --placement split --direction right --focus'
+description = "open herdr-browser in right split"
+
+[[keys.command]]
 key = "prefix+ctrl+right"
 type = "plugin_action"
 command = "local.claude-fork.right"
@@ -335,7 +343,7 @@ agent_panel_sort = "spaces"
 # allow_nested = false
 # Experimental local Kitty graphics rendering for attached clients.
 # Requires a Kitty graphics-compatible outer terminal.
-# kitty_graphics = false
+kitty_graphics = true
 # Save recent pane screen history across full server restarts.
 pane_history = false
 # While prefix mode is active, temporarily switch the macOS host input

--- a/.config/herdr/mdpreview/bun.lock
+++ b/.config/herdr/mdpreview/bun.lock
@@ -1,0 +1,250 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mdpreview",
+      "dependencies": {
+        "github-markdown-css": "^5.9.0",
+        "highlight.js": "^11.11.1",
+        "marked": "^18.0.9",
+        "marked-alert": "^2.1.2",
+        "marked-gfm-heading-id": "^4.1.4",
+        "mermaid": "^11.16.0",
+      },
+    },
+  },
+  "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.1", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
+    "github-markdown-css": ["github-markdown-css@5.9.0", "", {}, "sha512-tmT5sY+zvg2302XLYEfH2mtkViIM1SWf2nvYoF5N1ZsO0V6B2qZTiw3GOzw4vpjLygK/KG35qRlPFweHqfzz5w=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "marked": ["marked@18.0.9", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w=="],
+
+    "marked-alert": ["marked-alert@2.1.2", "", { "peerDependencies": { "marked": ">=7.0.0" } }, "sha512-EFNRZ08d8L/iEIPLTlQMDjvwIsj03gxWCczYTht6DCiHJIZhMk4NK5gtPY9UqAYb09eV5VGT+jD4lp396E0I+w=="],
+
+    "marked-gfm-heading-id": ["marked-gfm-heading-id@4.1.4", "", { "dependencies": { "github-slugger": "^2.0.0" }, "peerDependencies": { "marked": ">=13 <19" } }, "sha512-CspnvVfHSkb/znqdPS4jUR8HtCjq3M/DnrsJCrfLBLvdrgbemmoINKpeWKQYkBiXAoBGejw0cV7xzqrPdup3WA=="],
+
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+  }
+}

--- a/.config/herdr/mdpreview/package.json
+++ b/.config/herdr/mdpreview/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mdpreview",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run server.ts"
+  },
+  "dependencies": {
+    "github-markdown-css": "^5.9.0",
+    "highlight.js": "^11.11.1",
+    "marked": "^18.0.9",
+    "marked-alert": "^2.1.2",
+    "marked-gfm-heading-id": "^4.1.4",
+    "mermaid": "^11.16.0"
+  }
+}

--- a/.config/herdr/mdpreview/server.ts
+++ b/.config/herdr/mdpreview/server.ts
@@ -1,0 +1,264 @@
+// Local markdown preview server.
+//
+// Markdown, syntax highlighting, GitHub alerts and the table of contents are
+// rendered here in Bun. Mermaid is the one thing that needs a DOM, so its
+// fences are passed through as <pre class="mermaid"> and drawn by mermaid.js
+// in the browser that displays the page.
+
+import { watch, type FSWatcher } from "node:fs";
+import { basename, dirname, extname, resolve } from "node:path";
+
+import hljs from "highlight.js";
+import { Marked } from "marked";
+import markedAlert from "marked-alert";
+import { getHeadingList, gfmHeadingId, resetHeadings } from "marked-gfm-heading-id";
+
+const PORT = Number(process.env.MDPREVIEW_PORT ?? 43128);
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"]);
+
+const ASSETS: Record<string, string> = {
+  "/assets/github-markdown.css": "github-markdown-css/github-markdown.css",
+  "/assets/hljs-light.css": "highlight.js/styles/github.min.css",
+  "/assets/hljs-dark.css": "highlight.js/styles/github-dark.min.css",
+  "/assets/mermaid.min.js": "mermaid/dist/mermaid.min.js",
+};
+
+const marked = new Marked(
+  gfmHeadingId(),
+  markedAlert(),
+  {
+    gfm: true,
+    breaks: false,
+    renderer: {
+      code({ text, lang }) {
+        const language = (lang ?? "").trim().split(/\s+/)[0] ?? "";
+        // Hand mermaid to the browser instead of highlighting it.
+        if (language === "mermaid") {
+          return `<pre class="mermaid">${escapeHtml(text)}</pre>`;
+        }
+        if (language && hljs.getLanguage(language)) {
+          const { value } = hljs.highlight(text, { language, ignoreIllegals: true });
+          return `<pre><code class="hljs language-${escapeHtml(language)}">${value}</code></pre>`;
+        }
+        return `<pre><code class="hljs">${escapeHtml(text)}</code></pre>`;
+      },
+    },
+  },
+);
+
+let currentFile: string | null = null;
+let watcher: FSWatcher | null = null;
+let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function broadcastReload(): void {
+  const payload = new TextEncoder().encode("data: reload\n\n");
+  for (const client of clients) {
+    try {
+      client.enqueue(payload);
+    } catch {
+      clients.delete(client);
+    }
+  }
+}
+
+// Watch the containing directory rather than the file: editors that save by
+// writing a temp file and renaming it over the original break a file watch.
+function watchFile(file: string): void {
+  watcher?.close();
+  const name = basename(file);
+  watcher = watch(dirname(file), (_event, changed) => {
+    if (changed !== name) {
+      return;
+    }
+    if (reloadTimer) {
+      clearTimeout(reloadTimer);
+    }
+    reloadTimer = setTimeout(broadcastReload, 50);
+  });
+}
+
+async function setCurrentFile(rawPath: string): Promise<string> {
+  const file = resolve(rawPath);
+  if (!MARKDOWN_EXTENSIONS.has(extname(file).toLowerCase())) {
+    throw new Error(`not a markdown file: ${file}`);
+  }
+  if (!(await Bun.file(file).exists())) {
+    throw new Error(`no such file: ${file}`);
+  }
+  currentFile = file;
+  watchFile(file);
+  return file;
+}
+
+function renderToc(): string {
+  const headings = getHeadingList().filter((heading) => heading.level <= 3);
+  if (headings.length < 2) {
+    return "";
+  }
+  const items = headings
+    .map(
+      (heading) =>
+        `<li class="toc-l${heading.level}"><a href="#${escapeHtml(heading.id)}">${heading.text}</a></li>`,
+    )
+    .join("");
+  return `<nav class="toc"><div class="toc-title">Contents</div><ul>${items}</ul></nav>`;
+}
+
+async function renderPage(): Promise<Response> {
+  if (!currentFile) {
+    return new Response(shell("mdpreview", "", "<p>No file selected.</p>"), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+  const source = await Bun.file(currentFile).text();
+  resetHeadings();
+  const body = await marked.parse(source);
+  return new Response(shell(basename(currentFile), currentFile, body, renderToc()), {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+function shell(title: string, path: string, body: string, toc = ""): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<link rel="stylesheet" href="/assets/github-markdown.css">
+<link rel="stylesheet" href="/assets/hljs-light.css" media="(prefers-color-scheme: light)">
+<link rel="stylesheet" href="/assets/hljs-dark.css" media="(prefers-color-scheme: dark)">
+<style>
+  :root { color-scheme: light dark; }
+  body { margin: 0; background: var(--bgColor-default, #fff); }
+  .layout { display: flex; gap: 32px; align-items: flex-start;
+            max-width: 1280px; margin: 0 auto; padding: 32px; }
+  .content { flex: 1 1 auto; min-width: 0; }
+  .path { font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+          color: var(--fgColor-muted, #59636e); margin-bottom: 8px; }
+  .markdown-body { border: 1px solid var(--borderColor-default, #d1d9e0);
+                   border-radius: 6px; padding: 32px; }
+  .toc { position: sticky; top: 32px; flex: 0 0 240px; font-size: 13px;
+         border-left: 1px solid var(--borderColor-default, #d1d9e0); padding-left: 16px; }
+  .toc-title { font-weight: 600; margin-bottom: 8px;
+               color: var(--fgColor-muted, #59636e); }
+  .toc ul { list-style: none; margin: 0; padding: 0; }
+  .toc li { margin: 4px 0; }
+  .toc a { color: var(--fgColor-default, #1f2328); text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+  .toc-l2 { padding-left: 12px; }
+  .toc-l3 { padding-left: 24px; }
+  pre.mermaid { background: none; text-align: center; }
+  @media (max-width: 900px) { .toc { display: none; } }
+</style>
+</head>
+<body>
+<div class="layout">
+  <div class="content">
+    <div class="path">${escapeHtml(path)}</div>
+    <article class="markdown-body">${body}</article>
+  </div>
+  ${toc}
+</div>
+<script src="/assets/mermaid.min.js"></script>
+<script>
+  const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  mermaid.initialize({ startOnLoad: false, theme: dark ? "dark" : "default" });
+  mermaid.run({ querySelector: "pre.mermaid" });
+  new EventSource("/events").onmessage = () => location.reload();
+</script>
+</body>
+</html>`;
+}
+
+async function serveAsset(pathname: string): Promise<Response> {
+  const relative = ASSETS[pathname];
+  if (!relative) {
+    return new Response("not found", { status: 404 });
+  }
+  const file = Bun.file(resolve(import.meta.dir, "node_modules", relative));
+  if (!(await file.exists())) {
+    return new Response("asset missing - run bun install", { status: 500 });
+  }
+  return new Response(file, {
+    headers: {
+      "content-type": pathname.endsWith(".css")
+        ? "text/css; charset=utf-8"
+        : "text/javascript; charset=utf-8",
+    },
+  });
+}
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: PORT,
+  idleTimeout: 0,
+  async fetch(request) {
+    const { pathname } = new URL(request.url);
+
+    if (pathname === "/health") {
+      return Response.json({ ok: true, file: currentFile });
+    }
+
+    if (pathname === "/open" && request.method === "POST") {
+      const { path } = (await request.json()) as { path?: string };
+      if (!path) {
+        return Response.json({ ok: false, error: "missing path" }, { status: 400 });
+      }
+      try {
+        const file = await setCurrentFile(path);
+        broadcastReload();
+        return Response.json({ ok: true, file });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return Response.json({ ok: false, error: message }, { status: 400 });
+      }
+    }
+
+    if (pathname === "/events") {
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            clients.add(controller);
+          },
+          cancel(controller) {
+            clients.delete(controller);
+          },
+        }),
+        {
+          headers: {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          },
+        },
+      );
+    }
+
+    if (pathname.startsWith("/assets/")) {
+      return serveAsset(pathname);
+    }
+
+    if (pathname === "/") {
+      return renderPage();
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+const initial = process.argv[2];
+if (initial) {
+  await setCurrentFile(initial);
+}
+
+console.log(`mdpreview listening on http://127.0.0.1:${server.port}`);

--- a/.config/herdr/mdpreview/server.ts
+++ b/.config/herdr/mdpreview/server.ts
@@ -59,12 +59,16 @@ let watchedState = "";
 let reloadTimer: ReturnType<typeof setTimeout> | null = null;
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 
+// Callers drop the result into text nodes and double-quoted attributes, so &#39;
+// buys nothing today -- it is there so a future single-quoted attribute cannot
+// be broken out of. & stays first or it would re-escape the entities below it.
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }
 
 function broadcastReload(): void {

--- a/.config/herdr/mdpreview/server.ts
+++ b/.config/herdr/mdpreview/server.ts
@@ -18,6 +18,10 @@ import { getHeadingList, gfmHeadingId } from "marked-gfm-heading-id";
 // bin/mdpreview's ${MDPREVIEW_PORT:-43128} still talks to 43128.
 const PORT = Number(process.env.MDPREVIEW_PORT) || 43128;
 const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"]);
+// The names the page is ever legitimately reached under. A DNS rebinding attack
+// resolves the attacker's own hostname to 127.0.0.1, and the Host header is what
+// gives that away.
+const ALLOWED_HOSTS = new Set([`127.0.0.1:${PORT}`, `localhost:${PORT}`]);
 
 const ASSETS: Record<string, string> = {
   "/assets/github-markdown.css": "github-markdown-css/github-markdown.css",
@@ -135,11 +139,50 @@ function renderToc(): string {
   return `<nav class="toc"><div class="toc-title">Contents</div><ul>${items}</ul></nav>`;
 }
 
+function newNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+// The page's own two scripts carry this request's nonce, and script-src trusts
+// nothing else -- no host source, no 'unsafe-inline'. That is what makes the raw
+// HTML marked passes through inert: an injected <script> has no nonce, and an
+// onerror= attribute cannot be nonced at all, so both are refused.
+function contentSecurityPolicy(nonce: string): string {
+  return [
+    "default-src 'none'",
+    `script-src 'nonce-${nonce}'`,
+    // The two stylesheet links are 'self'; mermaid injects <style> at runtime.
+    "style-src 'self' 'unsafe-inline'",
+    // README badges are remote, and github-markdown-css inlines data: SVGs.
+    "img-src 'self' data: https:",
+    // new EventSource("/events").
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'none'",
+  ].join("; ");
+}
+
+function htmlResponse(
+  nonce: string,
+  title: string,
+  path: string,
+  body: string,
+  toc = "",
+): Response {
+  return new Response(shell(nonce, title, path, body, toc), {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "content-security-policy": contentSecurityPolicy(nonce),
+    },
+  });
+}
+
 async function renderPage(): Promise<Response> {
+  const nonce = newNonce();
   if (!currentFile) {
-    return new Response(shell("mdpreview", "", "<p>No file selected.</p>"), {
-      headers: { "content-type": "text/html; charset=utf-8" },
-    });
+    return htmlResponse(nonce, "mdpreview", "", "<p>No file selected.</p>");
   }
   let source: string;
   try {
@@ -149,19 +192,19 @@ async function renderPage(): Promise<Response> {
     // the shell anyway so the page keeps its /events listener and recovers on the
     // next change, instead of turning into Bun's 500 page and going deaf.
     const message = error instanceof Error ? error.message : String(error);
-    return new Response(
-      shell(basename(currentFile), currentFile, `<p>${escapeHtml(message)}</p>`),
-      { headers: { "content-type": "text/html; charset=utf-8" } },
+    return htmlResponse(
+      nonce,
+      basename(currentFile),
+      currentFile,
+      `<p>${escapeHtml(message)}</p>`,
     );
   }
   // gfmHeadingId's preprocess hook clears the heading list on every parse.
   const body = await marked.parse(source);
-  return new Response(shell(basename(currentFile), currentFile, body, renderToc()), {
-    headers: { "content-type": "text/html; charset=utf-8" },
-  });
+  return htmlResponse(nonce, basename(currentFile), currentFile, body, renderToc());
 }
 
-function shell(title: string, path: string, body: string, toc = ""): string {
+function shell(nonce: string, title: string, path: string, body: string, toc = ""): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -203,8 +246,8 @@ function shell(title: string, path: string, body: string, toc = ""): string {
   </div>
   ${toc}
 </div>
-<script src="/assets/mermaid.min.js"></script>
-<script>
+<script src="/assets/mermaid.min.js" nonce="${nonce}"></script>
+<script nonce="${nonce}">
   const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   mermaid.initialize({ startOnLoad: false, theme: dark ? "dark" : "default" });
   mermaid.run({ querySelector: "pre.mermaid" });
@@ -239,11 +282,20 @@ const server = Bun.serve({
   async fetch(request) {
     const { pathname } = new URL(request.url);
 
+    if (!ALLOWED_HOSTS.has(request.headers.get("host") ?? "")) {
+      return new Response("forbidden", { status: 403 });
+    }
+
     if (pathname === "/health") {
       return Response.json({ ok: true, file: currentFile });
     }
 
     if (pathname === "/open" && request.method === "POST") {
+      // Only local tooling posts here. A page in a browser always attaches an
+      // Origin, so its presence means the request came from somewhere else.
+      if (request.headers.get("origin") !== null) {
+        return new Response("forbidden", { status: 403 });
+      }
       const { path } = (await request.json()) as { path?: string };
       if (!path) {
         return Response.json({ ok: false, error: "missing path" }, { status: 400 });

--- a/.config/herdr/mdpreview/server.ts
+++ b/.config/herdr/mdpreview/server.ts
@@ -5,7 +5,7 @@
 // fences are passed through as <pre class="mermaid"> and drawn by mermaid.js
 // in the browser that displays the page.
 
-import { statSync, watch, type FSWatcher } from "node:fs";
+import { realpathSync, statSync, watch, type FSWatcher } from "node:fs";
 import { basename, dirname, extname, resolve } from "node:path";
 
 import hljs from "highlight.js";
@@ -54,7 +54,7 @@ const marked = new Marked(
 );
 
 let currentFile: string | null = null;
-let watcher: FSWatcher | null = null;
+let watchers: FSWatcher[] = [];
 let watchedState = "";
 let reloadTimer: ReturnType<typeof setTimeout> | null = null;
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
@@ -94,26 +94,62 @@ function fileState(file: string): string {
   }
 }
 
+// The literal path with every symlink -- the file itself and any parent
+// directory -- resolved away. Falls back to the path as given, which is what a
+// broken link or a file that vanished mid-save leaves us with.
+function realPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
 // Watch the containing directory rather than the file: editors that save by
 // writing a temp file and renaming it over the original break a file watch.
 // macOS reports only the source name for that rename, so the watched file's own
 // name may never show up in an event. Fall back to comparing the fingerprint,
 // which also keeps unrelated saves in the same directory from reloading.
+//
+// A symlinked target needs the real file's directory watched as well: writes
+// land over there and the link's own directory never hears about them, so no
+// event arrives and the fingerprint -- which statSync already reads through the
+// link -- never gets an occasion to be compared. The link's directory stays
+// watched too, so repointing or replacing the link itself still reloads.
+// Directories are keyed by their resolved path, so the ordinary case where the
+// two differ only in a parent symlink (/tmp vs /private/tmp) collapses back to
+// the single watch it has always been.
 function watchFile(file: string): void {
-  watcher?.close();
-  const name = basename(file);
+  for (const open of watchers) {
+    open.close();
+  }
+  watchers = [];
   watchedState = fileState(file);
-  watcher = watch(dirname(file), (_event, changed) => {
-    const state = fileState(file);
-    if (changed !== name && state === watchedState) {
-      return;
-    }
-    watchedState = state;
-    if (reloadTimer) {
-      clearTimeout(reloadTimer);
-    }
-    reloadTimer = setTimeout(broadcastReload, 50);
-  });
+  const names = new Map<string, Set<string>>();
+  for (const path of [file, realPath(file)]) {
+    const dir = realPath(dirname(path));
+    const known = names.get(dir) ?? new Set<string>();
+    known.add(basename(path));
+    names.set(dir, known);
+  }
+  for (const [dir, known] of names) {
+    watchers.push(
+      watch(dir, (_event, changed) => {
+        // Fingerprint the path as opened, not the resolved one: statSync follows
+        // the link, so one comparison covers both an edit to the real file and a
+        // link repointed at a different file.
+        const state = fileState(file);
+        if (!known.has(changed ?? "") && state === watchedState) {
+          return;
+        }
+        watchedState = state;
+        if (reloadTimer) {
+          clearTimeout(reloadTimer);
+        }
+        reloadTimer = setTimeout(broadcastReload, 50);
+      }),
+    );
+  }
 }
 
 async function setCurrentFile(rawPath: string): Promise<string> {

--- a/.config/herdr/mdpreview/server.ts
+++ b/.config/herdr/mdpreview/server.ts
@@ -5,15 +5,18 @@
 // fences are passed through as <pre class="mermaid"> and drawn by mermaid.js
 // in the browser that displays the page.
 
-import { watch, type FSWatcher } from "node:fs";
+import { statSync, watch, type FSWatcher } from "node:fs";
 import { basename, dirname, extname, resolve } from "node:path";
 
 import hljs from "highlight.js";
 import { Marked } from "marked";
 import markedAlert from "marked-alert";
-import { getHeadingList, gfmHeadingId, resetHeadings } from "marked-gfm-heading-id";
+import { getHeadingList, gfmHeadingId } from "marked-gfm-heading-id";
 
-const PORT = Number(process.env.MDPREVIEW_PORT ?? 43128);
+// Coerce with || rather than ??: an exported-but-empty MDPREVIEW_PORT would
+// otherwise become Number("") === 0 and make Bun listen on a random port, while
+// bin/mdpreview's ${MDPREVIEW_PORT:-43128} still talks to 43128.
+const PORT = Number(process.env.MDPREVIEW_PORT) || 43128;
 const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"]);
 
 const ASSETS: Record<string, string> = {
@@ -48,6 +51,7 @@ const marked = new Marked(
 
 let currentFile: string | null = null;
 let watcher: FSWatcher | null = null;
+let watchedState = "";
 let reloadTimer: ReturnType<typeof setTimeout> | null = null;
 const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 
@@ -70,15 +74,33 @@ function broadcastReload(): void {
   }
 }
 
+// A stat fingerprint of the watched file. The inode changes when an editor
+// renames a freshly written file over the original, and "missing" covers the
+// window while the file is gone.
+function fileState(file: string): string {
+  try {
+    const info = statSync(file);
+    return `${info.ino}:${info.size}:${info.mtimeMs}`;
+  } catch {
+    return "missing";
+  }
+}
+
 // Watch the containing directory rather than the file: editors that save by
 // writing a temp file and renaming it over the original break a file watch.
+// macOS reports only the source name for that rename, so the watched file's own
+// name may never show up in an event. Fall back to comparing the fingerprint,
+// which also keeps unrelated saves in the same directory from reloading.
 function watchFile(file: string): void {
   watcher?.close();
   const name = basename(file);
+  watchedState = fileState(file);
   watcher = watch(dirname(file), (_event, changed) => {
-    if (changed !== name) {
+    const state = fileState(file);
+    if (changed !== name && state === watchedState) {
       return;
     }
+    watchedState = state;
     if (reloadTimer) {
       clearTimeout(reloadTimer);
     }
@@ -119,8 +141,20 @@ async function renderPage(): Promise<Response> {
       headers: { "content-type": "text/html; charset=utf-8" },
     });
   }
-  const source = await Bun.file(currentFile).text();
-  resetHeadings();
+  let source: string;
+  try {
+    source = await Bun.file(currentFile).text();
+  } catch (error) {
+    // An editor or `git checkout` can leave the file missing for a moment. Serve
+    // the shell anyway so the page keeps its /events listener and recovers on the
+    // next change, instead of turning into Bun's 500 page and going deaf.
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(
+      shell(basename(currentFile), currentFile, `<p>${escapeHtml(message)}</p>`),
+      { headers: { "content-type": "text/html; charset=utf-8" } },
+    );
+  }
+  // gfmHeadingId's preprocess hook clears the heading list on every parse.
   const body = await marked.parse(source);
   return new Response(shell(basename(currentFile), currentFile, body, renderToc()), {
     headers: { "content-type": "text/html; charset=utf-8" },
@@ -225,13 +259,19 @@ const server = Bun.serve({
     }
 
     if (pathname === "/events") {
+      // cancel() is handed the cancellation reason, not the controller, so hold
+      // our own reference to drop the client when the page goes away.
+      let client: ReadableStreamDefaultController<Uint8Array> | null = null;
       return new Response(
         new ReadableStream({
           start(controller) {
+            client = controller;
             clients.add(controller);
           },
-          cancel(controller) {
-            clients.delete(controller);
+          cancel() {
+            if (client) {
+              clients.delete(client);
+            }
           },
         }),
         {

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 \#*\#
 .DS_*
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,24 @@
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/claude-fork
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-diff
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-gh-diff
+
+#herdr-browser
+
+Chromium をペインに埋め込むプラグイン。Kitty graphics 対応ターミナル (Ghostty など)、
+Chrome/Chromium、bun が必要。config.toml の `[experimental] kitty_graphics = true`
+と `prefix+alt+b` のキーバインドは追跡済み。
+
+	herdr plugin install ogulcancelik/herdr-browser --yes
+
+	mise use -g bun@latest
+
+bun は `mise activate` 経由なので対話 zsh にしか PATH が通らない。herdr サーバーが
+プラグインペインを spawn するときに見つけられるよう、シムを ~/bin (zshenv で PATH に
+入る) に置く。
+
+	ln -sfn ~/.local/share/mise/shims/bun ~/bin/bun
+
+CLI ラッパー (`herdr-browser open <url>`, `text`, `selector-click`, `console` など。
+Claude Code から Bash で叩く用):
+
+	ln -sf ~/src/github.com/motchang/dotfiles/.config/herdr/bin/herdr-browser ~/bin/herdr-browser

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#install
+# install
 
 	mkdir -p src/github.com/motchang/dotfiles
 	git clone https://github.com/motchang/dotfiles.git src/github.com/motchang/dotfiles/
@@ -27,7 +27,7 @@
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-diff
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-gh-diff
 
-#herdr-browser
+# herdr-browser
 
 Chromium をペインに埋め込むプラグイン。Kitty graphics 対応ターミナル (Ghostty など)、
 Chrome/Chromium、bun が必要。config.toml の `[experimental] kitty_graphics = true`

--- a/README.md
+++ b/README.md
@@ -47,3 +47,21 @@ CLI ラッパー (`herdr-browser open <url>`, `text`, `selector-click`, `console
 Claude Code から Bash で叩く用):
 
 	ln -sf ~/src/github.com/motchang/dotfiles/.config/herdr/bin/herdr-browser ~/bin/herdr-browser
+
+# mdpreview
+
+Markdown を herdr-browser のペインでプレビューする。埋め込み mermaid も描画され、
+ファイルを保存すると自動でリロードされる。ネットワークには出ない (mermaid.js も
+highlight.js もローカル配信)。
+
+markdown・シンタックスハイライト・GitHub alerts・目次は Bun 側でレンダリングし、
+DOM を必要とする mermaid だけをブラウザ側で描画する。
+
+	cd ~/src/github.com/motchang/dotfiles/.config/herdr/mdpreview && bun install
+
+	ln -sf ~/src/github.com/motchang/dotfiles/.config/herdr/bin/mdpreview ~/bin/mdpreview
+
+使い方 (ポートは MDPREVIEW_PORT で変更可、既定 43128):
+
+	mdpreview README.md
+	mdpreview --stop


### PR DESCRIPTION
## Summary
- Sets up the `official.browser` herdr plugin with a CLI wrapper (`herdr-browser`) so the pane is drivable from Bash, plus the `prefix+alt+b` binding and the experimental `kitty_graphics` renderer it requires
- Adds `mdpreview`: renders a markdown file locally (marked, highlight.js, GitHub alerts and the TOC in Bun; mermaid drawn in the page, which needs a DOM) and displays it in a browser pane with live reload. Previewing a README no longer means POSTing it to GitHub's `/markdown` API, so no network and no authenticated `gh`
- The last five commits are fixes from re-reviewing the first three in a separate, independent session. Each was verified before it landed, and one of them only exists because the second reviewer caught what the first missed

### What the review fixes changed
- `20fe09c` — live reload never fired for editors that save by writing a temp file and renaming it over the original: macOS reports only the source name for that rename, so the basename filter dropped exactly the case the directory watch existed for. Also, a file that vanished for a moment left the page on Bun's 500 page, which carries no `/events` listener, so it never recovered. Plus: an empty `MDPREVIEW_PORT` became `Number("") === 0` and listened on a random port; a stream's `cancel()` is handed the cancellation reason, not the controller; and a server that never came up exited under `set -e` with no output at all
- `0e4eafa` — marked passes raw HTML through, so a `<script>` in a previewed file ran on the preview's own origin, and `/open` accepts any path: a README from a cloned repo could read any `.md` on disk and send it anywhere. `script-src` now trusts a per-response nonce and nothing else, which makes both an injected `<script>` and an `onerror=` attribute inert, and the Host header and a `POST /open` carrying an `Origin` are refused
- `4db3d8f` — `jq '.views | length'` evaluates `null | length` as 0, so any shape without a top-level `.views` array read as "no views" and stacked up another pane on every run
- `4f5d040` — `escapeHtml` now escapes `'`. Defensive only; every current caller uses text nodes or double-quoted attributes
- `b0ec4fb` — previewing a symlink never reloaded on edits to the target, because writes land in the target's directory and the link's own directory never hears about them

## Test plan
- [x] Live reload verified by counting `/events` reloads across 11 scenarios: temp+rename, in-place write, unlink-then-recreate, same-content rename, an unrelated file in the same directory, and the symlink equivalents including repointing the link. A negative control against the previous watcher confirmed the suite actually measures the fix
- [x] CSP verified in a real Chrome pane against a file carrying `<script>`, `onerror=`, a mermaid fence and a remote badge at once: neither the script nor the attribute ran, while mermaid still drew, highlight.js still styled, the badge still loaded, and an atomic save still triggered the reload
- [x] `Host: evil.example.com` → 403; `POST /open` with an `Origin` → 403; the `content-type: text/plain` path that skips CORS preflight is still refused by the extension check
- [x] `views` branch verified against stubs: a missing binary, a failing command, empty output, garbage, and a missing / null / wrapped / non-array `.views` all exit 1 with a message, while `views: []` still opens a pane and a non-empty list still navigates
- [x] Heading ids stable across repeated renders after dropping the redundant `resetHeadings()`; apostrophe escaping round-trips through the HTML parser for mermaid fences
- [x] `sh -n` on `bin/mdpreview`, and the server booted on a spare port for every change (which also covers type stripping and imports)

## Note
`kitty_graphics = true` in `config.toml` is an experimental global setting that the browser plugin requires, so it only makes sense on a machine whose terminal supports Kitty graphics. That is the premise of this machine-specific branch, and the requirement is written down in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
