### PR TITLE
Split off a fresh Claude session, not only a forked one

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -182,6 +182,23 @@ key = "prefix+ctrl+down"
 type = "plugin_action"
 command = "local.claude-fork.down"
 
+# claude-fresh reuses the 2/3 split numbering above rather than pairing with
+# claude-fork's ctrl+arrows: `alt+arrow_left`/`alt+arrow_right` are the only two
+# bare alt+ bindings Ghostty ships, and it rewrites them to esc:b/esc:f, so
+# prefix+alt+right arrives as alt+f and can never match. The other arrow
+# modifiers are spoken for too (shift = adjust_selection, super = text:\x05,
+# super+alt = goto_split). So: prefix+2/3 splits empty, prefix+alt+2/3 splits
+# with a fresh claude in it, prefix+ctrl+arrow splits with a forked one.
+[[keys.command]]
+key = "prefix+alt+3"     # side-by-side, matching split_vertical
+type = "plugin_action"
+command = "local.claude-fresh.right"
+
+[[keys.command]]
+key = "prefix+alt+2"     # stacked, matching split_horizontal
+type = "plugin_action"
+command = "local.claude-fresh.down"
+
 
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.

--- a/.config/herdr/plugins/claude-fresh/fresh.sh
+++ b/.config/herdr/plugins/claude-fresh/fresh.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Open a *fresh* Claude Code session in a new split pane next to the pane this
+# action ran from. Sibling of ../claude-fork: same split-then-launch shape, but
+# a brand-new conversation instead of `--fork-session`'s carried-over history.
+#
+# What carries over: the source pane's cwd, its `--add-dir` set, and
+# CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD. Together those are what `cw`
+# hands a pane to give it its multi-repo view, so a fresh sibling that dropped
+# them would quietly see a different set of repos than the pane it came from.
+#
+# What deliberately does not carry over: everything else in the source argv.
+# --resume/--continue and a one-shot prompt are exactly what "fresh" rules out,
+# and a pane created by claude-fork runs with `--resume <id> --fork-session`, so
+# blanket argv reuse would make "fresh" fork the conversation instead.
+#
+# Both `herdr pane split` and `herdr pane run` go through the pane's interactive
+# zsh — `pane run` is send-text-plus-Enter, which is why `exec` (a shell
+# builtin, with no binary of that name) works and replaces zsh with claude.
+#
+# Set CLAUDE_FRESH_DRY_RUN=1 to print the two herdr calls without running them.
+set -euo pipefail
+
+direction="${1:-right}"
+case "$direction" in
+  right|down) ;;
+  *)
+    echo "usage: fresh.sh [right|down]" >&2
+    exit 1
+    ;;
+esac
+
+pane_id="${HERDR_PANE_ID:?HERDR_PANE_ID not set — run this action from a pane context}"
+
+cwd=$(herdr pane get "$pane_id" | jq -r '.result.pane.cwd')
+
+# The pane's Claude process. Prefer the foreground process group leader so a
+# nested `claude` spawned by a Bash tool call can't be mistaken for the session.
+claude_json=$(herdr pane process-info --pane "$pane_id" | jq -c '
+  .result.process_info as $pi
+  | [ $pi.foreground_processes[]
+      | select((.argv[0] | split("/") | last) == "claude") ] as $c
+  | ( [ $c[] | select(.pid == $pi.foreground_process_group_id) ] + $c )
+  | .[0] // empty
+')
+
+if [ -z "$claude_json" ]; then
+  echo "No Claude Code process found in pane $pane_id" >&2
+  exit 1
+fi
+
+# --- carry over the --add-dir set -------------------------------------------
+# `--add-dir` is variadic, so consume tokens after it until the next flag, and
+# accept the --add-dir=PATH spelling too.
+src_argv=()
+while IFS= read -r arg; do
+  src_argv+=("$arg")
+done < <(jq -r '.argv[1:][]' <<<"$claude_json")
+
+add_dirs=()
+i=0
+n=${#src_argv[@]}
+while [ "$i" -lt "$n" ]; do
+  case "${src_argv[$i]}" in
+    --add-dir)
+      i=$((i + 1))
+      while [ "$i" -lt "$n" ]; do
+        case "${src_argv[$i]}" in
+          -*) break ;;
+          *) add_dirs+=("${src_argv[$i]}"); i=$((i + 1)) ;;
+        esac
+      done
+      continue
+      ;;
+    --add-dir=*)
+      add_dirs+=("${src_argv[$i]#--add-dir=}")
+      ;;
+  esac
+  i=$((i + 1))
+done
+
+# --- carry over the additional-CLAUDE.md opt-in -----------------------------
+# Read it off the live process rather than this script's own environment: plugin
+# actions run from the herdr server, not from the pane.
+md_var=CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD
+claude_pid=$(jq -r '.pid' <<<"$claude_json")
+if [ -r "/proc/$claude_pid/environ" ]; then
+  md_val=$(tr '\0' '\n' < "/proc/$claude_pid/environ" | sed -n "s/^$md_var=//p" | head -1)
+else
+  # macOS: `ps -E` appends the environment to the command, space separated. That
+  # split is only safe for a value that cannot contain a space, so require one.
+  md_val=$(ps -p "$claude_pid" -E -o command= 2>/dev/null \
+    | tr ' ' '\n' | sed -n "s/^$md_var=//p" | head -1)
+fi
+env_flags=()
+case "$md_val" in
+  '') ;;
+  *[!A-Za-z0-9_.:/-]*) ;;
+  *) env_flags=(--env "$md_var=$md_val") ;;
+esac
+
+# --- build the launch line ---------------------------------------------------
+# `pane run` sends literal text to zsh, so each path has to arrive quoted.
+shq() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+cmd="exec claude"
+for d in ${add_dirs[@]+"${add_dirs[@]}"}; do
+  cmd="$cmd --add-dir $(shq "$d")"
+done
+
+if [ -n "${CLAUDE_FRESH_DRY_RUN:-}" ]; then
+  printf 'herdr pane split --pane %s --direction %s --cwd %s%s --focus\n' \
+    "$pane_id" "$direction" "$(shq "$cwd")" \
+    "$( [ ${#env_flags[@]} -gt 0 ] && printf ' --env %s' "$(shq "${env_flags[1]}")" )"
+  printf 'herdr pane run <new-pane> %s\n' "$cmd"
+  exit 0
+fi
+
+split_json=$(herdr pane split --pane "$pane_id" --direction "$direction" --cwd "$cwd" \
+  ${env_flags[@]+"${env_flags[@]}"} --focus)
+new_pane_id=$(jq -r '.result.pane.pane_id' <<<"$split_json")
+
+herdr pane run "$new_pane_id" "$cmd"

--- a/.config/herdr/plugins/claude-fresh/fresh.sh
+++ b/.config/herdr/plugins/claude-fresh/fresh.sh
@@ -56,6 +56,19 @@ while IFS= read -r arg; do
   src_argv+=("$arg")
 done < <(jq -r '.argv[1:][]' <<<"$claude_json")
 
+# A variadic group's end is ambiguous: `cw` appends the caller's own claude args
+# after its generated --add-dir flags, so `cw <preset> "do the thing"` puts a
+# one-shot prompt exactly where another directory would go. --add-dir takes
+# directory paths, so require one — the prompt is not a directory, so it drops
+# out, which is what a fresh session wants anyway. Resolve relative to the source
+# pane rather than to this script, which runs from the herdr server's cwd.
+is_pane_dir() {
+  case "$1" in
+    /*) [ -d "$1" ] ;;
+    *)  [ -d "$cwd/$1" ] ;;
+  esac
+}
+
 add_dirs=()
 i=0
 n=${#src_argv[@]}
@@ -66,12 +79,15 @@ while [ "$i" -lt "$n" ]; do
       while [ "$i" -lt "$n" ]; do
         case "${src_argv[$i]}" in
           -*) break ;;
-          *) add_dirs+=("${src_argv[$i]}"); i=$((i + 1)) ;;
         esac
+        is_pane_dir "${src_argv[$i]}" || break
+        add_dirs+=("${src_argv[$i]}")
+        i=$((i + 1))
       done
       continue
       ;;
     --add-dir=*)
+      # Unambiguous spelling — a prompt cannot arrive this way, so take it as given.
       add_dirs+=("${src_argv[$i]#--add-dir=}")
       ;;
   esac

--- a/.config/herdr/plugins/claude-fresh/herdr-plugin.toml
+++ b/.config/herdr/plugins/claude-fresh/herdr-plugin.toml
@@ -1,0 +1,18 @@
+id = "local.claude-fresh"
+name = "Claude Fresh"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "Open a fresh Claude Code session in a new split pane, reusing the current pane's --add-dir set"
+platforms = ["macos", "linux"]
+
+[[actions]]
+id = "right"
+title = "Fresh Claude session (right)"
+contexts = ["pane"]
+command = ["bash", "fresh.sh", "right"]
+
+[[actions]]
+id = "down"
+title = "Fresh Claude session (down)"
+contexts = ["pane"]
+command = ["bash", "fresh.sh", "down"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ gibo: zshrc hooks direnv unguarded too, and direnv is a formula.
 	ln -sf ~/src/github.com/motchang/dotfiles/.config/hunk/config.toml ~/.config/hunk/config.toml
 
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/claude-fork
+	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/claude-fresh
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-diff
 	herdr plugin link ~/src/github.com/motchang/dotfiles/.config/herdr/plugins/hunk-gh-diff
 


### PR DESCRIPTION
## What

Adds a `local.claude-fresh` herdr plugin: split the current pane and start a
**new** Claude Code conversation in it, with the same repo view.

`local.claude-fork` already covers the carry-the-history case. There was no
equivalent for "same repos, blank slate" short of retyping the `cw` invocation.

## How it carries context

`herdr pane process-info --pane <id>` hands back the pane's Claude argv and pid,
so the new pane inherits:

- the source pane's `cwd`
- its `--add-dir` set (both the variadic and `--add-dir=PATH` spellings)
- `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD`

Those two together are what gives a `cw` pane its extra repos, so a sibling that
dropped them would silently see a different set. The env var is read off the live
process rather than inherited, because plugin actions run from the herdr server
and never see the pane's environment.

Everything else in the source argv is dropped deliberately. A pane made by
`claude-fork` runs `--resume <id> --fork-session`, so blanket argv reuse would
make "fresh" fork the conversation instead — the one behaviour it must not have.
It's an allowlist, so carrying `--model` etc. later is a small edit.

## Keybinding

`prefix+alt+3` (right) / `prefix+alt+2` (down), rather than pairing with fork's
`prefix+ctrl+arrow`.

`alt+arrow_left`/`alt+arrow_right` are the only two bare `alt+` bindings Ghostty
ships, and it rewrites them to `esc:b`/`esc:f` — so `prefix+alt+right` reaches
herdr as `alt+f` and can never match. That rewrite is worth keeping, since it is
what supplies Meta-b/Meta-f. The remaining arrow modifiers are taken as well
(`shift` = adjust_selection, `super` = `text:\x05`, `super+alt` = goto_split).

So `prefix+alt+2/3` instead, riding the C-x 2 / C-x 3 numbering that
`split_horizontal`/`split_vertical` already use.

## Verification

- Synthetic argv (`--resume <uuid> --fork-session --add-dir "/repo/add one" "/repo/o'brien" --model opus --add-dir=/repo/eq` plus a trailing prompt): only the three `--add-dir` paths survive, and the foreground-process-group-leader check ignores a nested decoy `claude`.
- The emitted line reparses correctly under `zsh -f` (paths with spaces and apostrophes).
- Live pane: `pane split --env` delivers the env var, and `pane run` text is executed by the new pane's zsh. Probe panes were closed.
- `herdr server reload-config` → `applied`, no diagnostics; both keys confirmed working by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)