### PR TITLE
Hold the fork until the source session's turn is finished

### DIFF
--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -3,6 +3,36 @@
 # pane, carrying over its conversation history via `claude --fork-session`.
 # Credit to miyagawa for the original approach:
 # https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
+#
+# The fork point is not ours to pick. `claude --resume <id> --fork-session`
+# starts from whatever the source session's transcript happens to hold on disk
+# at the instant the new process reads it, so a source that is mid-turn at that
+# instant yields a fork whose conversation is quietly truncated and whose last
+# answer is simply missing. Two ways that happens in practice:
+#
+#   1. A race. The key was pressed while the source was still working, so the
+#      answer had not been written out yet. A few seconds of waiting fixes it.
+#   2. An unanswered tool call - in the observed cases an AskUserQuestion the
+#      user had not answered. The API cannot accept a `tool_use` without its
+#      matching `tool_result`, so the fork has to rewind past that whole turn,
+#      and any `text` the model emitted in the same turn is discarded with it.
+#      One such loss was of text written 6m26s earlier: waiting does not help
+#      here, only answering the question does.
+#
+# One test catches both. Ignoring the sidecar entries a fork drops anyway, the
+# last entry in the transcript must be an `assistant` entry holding a `text`
+# block and no `tool_use` block. Deliberately NOT a whole-file scan for a
+# `tool_use` with no `tool_result`: the transcript is a tree, and a branch the
+# user abandoned with an interrupt leaves a dangling `tool_use` behind for good,
+# which would block forking forever. The tail test has no such false positive.
+#
+# The new pane is the only channel that reaches the user - toast notifications
+# are disabled on this machine, and whether a plugin action's stderr surfaces
+# anywhere at all is unknown - so the guard reports itself by writing into it.
+#
+# Set CLAUDE_FORK_NO_WAIT=1 to skip the guard and fork immediately.
+# Set CLAUDE_FORK_DRY_RUN=1 to print the decision and the herdr calls it implies
+# without splitting or running anything.
 set -euo pipefail
 
 direction="${1:-right}"
@@ -20,12 +50,236 @@ pane_json=$(herdr pane get "$pane_id")
 session_id=$(jq -r '.result.pane.agent_session.value // empty' <<<"$pane_json")
 cwd=$(jq -r '.result.pane.cwd' <<<"$pane_json")
 
+# Read this off the response we already have rather than calling `pane get`
+# twice. Observed values on this machine: idle, working, unknown.
+agent_status=$(jq -r '.result.pane.agent_status // empty' <<<"$pane_json")
+[ -n "$agent_status" ] || agent_status="unknown"
+
 if [ -z "$session_id" ]; then
   echo "No Claude Code session detected on pane $pane_id" >&2
   exit 1
 fi
 
+# `pane run` sends literal text to the pane's interactive zsh and presses Enter
+# (which is why `exec`, a shell builtin with no binary of that name, works
+# there), so anything interpolated into a command has to arrive already quoted.
+shq() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+fork_cmd="exec claude --resume $(shq "$session_id") --fork-session"
+
+# --- locate the transcript ---------------------------------------------------
+# Transcripts live at <config>/projects/<escaped-cwd>/<session-id>.jsonl. The
+# cwd-escaping rule is not worth reimplementing when the session id already
+# names the file uniquely; -maxdepth 2 keeps the search cheap and, usefully,
+# excludes subagent transcripts, which sit a level deeper under
+# <session-id>/subagents/. `find` is allowed to fail - see the fail-open note
+# where the decision is made.
+claude_config="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+transcript=$(find "$claude_config/projects" -maxdepth 2 -name "$session_id.jsonl" 2>/dev/null | head -1) || true
+
+# --- the completed-turn test -------------------------------------------------
+# Only `assistant` and `user` entries sit *on* the conversation. Every other
+# .type is a sidecar hanging off it that a fork does not carry: system/*
+# (turn_duration, stop_hook_summary, away_summary, informational), attachment,
+# last-prompt, file-history-snapshot, ai-title, mode, permission-mode,
+# atis-latch, pr-link, queue-operation and more. Whitelisting the two rather
+# than blacklisting the sidecars is deliberate, and load-bearing: of the 138
+# cleanly-finished transcripts on this machine, 112 have a *non*-`system`
+# sidecar sitting after their final assistant text, so a blacklist that only
+# skipped `system` would refuse four good forks out of five. The sidecar set
+# also grows with Claude Code releases, and an unfamiliar new .type has to fall
+# out as "ignore this", never as "the turn is unfinished".
+#
+# Sets tail_state / tail_kind / tail_detail. jq is allowed to fail: the source
+# may be appending to this very file, and a half-written last line should read
+# as "not finished yet" rather than take the script down under `set -e`.
+tail_state=""
+tail_kind=""
+tail_detail=""
+read_tail() {
+  local out
+  out=$(jq -n -r '
+    last(inputs | select(.type == "assistant" or .type == "user"))
+    | if . == null then "incomplete\tnone\t"
+      else ( (.message.content // []) | if type == "array" then . else [] end ) as $blocks
+        | if .type != "assistant" then
+            "incomplete\tuser\t"
+            + ( if ( [ $blocks[] | select(.type == "tool_result") ] | length ) > 0
+                then "tool_result" else "message" end )
+          else
+            ( [ $blocks[] | select(.type == "tool_use") ] | first ) as $pending
+            | if $pending != null then "incomplete\ttool_use\t" + ($pending.name // "")
+              elif ( [ $blocks[] | select(.type == "text") ] | length ) > 0 then "complete\t\t"
+              else "incomplete\tassistant\t" + ( ( [ $blocks[].type ] | first ) // "" )
+              end
+          end
+      end
+  ' "$1" 2>/dev/null) || out=""
+  [ -n "$out" ] || out=$(printf 'incomplete\tunreadable\t')
+  IFS=$'\t' read -r tail_state tail_kind tail_detail <<<"$out" || true
+  :
+}
+
+# --- decide ------------------------------------------------------------------
+wait_seconds=30
+decision="fork"
+reason=""
+
+if [ -n "${CLAUDE_FORK_NO_WAIT:-}" ]; then
+  reason="CLAUDE_FORK_NO_WAIT is set"
+elif [ -z "$transcript" ]; then
+  # Fail open, on purpose. The guard is best-effort and must never become the
+  # reason forking is impossible: if the on-disk layout changes under us, the
+  # right degradation is "forks exactly like it always did", not "cannot fork".
+  reason="no transcript found under $claude_config/projects"
+else
+  read_tail "$transcript"
+  if [ "$tail_state" = "complete" ]; then
+    reason="the source session's last turn is complete"
+  elif [ "$agent_status" = "idle" ]; then
+    # Nothing is running, so nothing is going to finish the turn on its own.
+    # Waiting here would only postpone the same refusal by wait_seconds.
+    decision="refuse"
+    reason="last turn is incomplete and the source pane is idle"
+  else
+    decision="wait"
+    reason="last turn is incomplete and the source pane is $agent_status"
+  fi
+fi
+
+# --- what the guard says in the pane -----------------------------------------
+notice_line="Fork: the source session is mid-turn - waiting up to ${wait_seconds}s for it to finish..."
+
+# `printf '%s\n' a b c` prints one line per argument, so a multi-line message
+# stays a single command with every line quoted on its own.
+printf_cmd() {
+  local cmd="printf '%s\\n'"
+  local line
+  for line in "$@"; do
+    cmd="$cmd $(shq "$line")"
+  done
+  printf '%s' "$cmd"
+}
+
+refusal_lines=()
+build_refusal() {
+  local timed_out="${1:-}"
+  refusal_lines=(
+    ""
+    "Fork not started: the source session's last turn is incomplete."
+    ""
+  )
+  if [ -n "$timed_out" ]; then
+    refusal_lines+=("  Waited ${wait_seconds}s for the turn to finish and it did not.")
+    refusal_lines+=("")
+  fi
+  case "$tail_kind" in
+    tool_use)
+      if [ "$tail_detail" = "AskUserQuestion" ]; then
+        refusal_lines+=("  The source is waiting on a question nobody has answered yet. Answer it in")
+        refusal_lines+=("  the source pane first and the fork will carry the whole conversation.")
+      elif [ -n "$tail_detail" ]; then
+        refusal_lines+=("  The source is sitting on a $tail_detail tool call with no result yet, so the")
+        refusal_lines+=("  turn it belongs to is still open.")
+      else
+        refusal_lines+=("  The source is sitting on a tool call with no result yet, so the turn it")
+        refusal_lines+=("  belongs to is still open.")
+      fi
+      ;;
+    user)
+      if [ "$tail_detail" = "tool_result" ]; then
+        refusal_lines+=("  The source's last entry is a tool result, so the turn that asked for it has")
+        refusal_lines+=("  not been answered yet.")
+      else
+        refusal_lines+=("  The source's last entry is a message to the assistant that has not been")
+        refusal_lines+=("  answered yet.")
+      fi
+      ;;
+    assistant)
+      refusal_lines+=("  The source's last entry is an assistant ${tail_detail:-non-text} block, so the turn")
+      refusal_lines+=("  has not been closed out with an answer.")
+      ;;
+    unreadable)
+      refusal_lines+=("  The transcript could not be parsed - most likely it is being written to")
+      refusal_lines+=("  right now.")
+      ;;
+    *)
+      refusal_lines+=("  The transcript has no finished assistant turn at its end.")
+      ;;
+  esac
+  refusal_lines+=("")
+  refusal_lines+=("Forking now would rewind past that unfinished turn, so the tail of the")
+  refusal_lines+=("conversation - including any answer already written inside it - would not")
+  refusal_lines+=("carry over.")
+  refusal_lines+=("")
+  refusal_lines+=("To fork anyway, paste:")
+  refusal_lines+=("")
+  refusal_lines+=("  claude --resume $(shq "$session_id") --fork-session")
+  refusal_lines+=("")
+}
+
+# zsh echoes a command line before running it, and the refusal is long enough
+# that its own quoted source would push the message off a short pane. Clear
+# first so what is left on screen is the message and a prompt.
+refusal_cmd() {
+  build_refusal "${1:-}"
+  printf 'clear; %s' "$(printf_cmd ${refusal_lines[@]+"${refusal_lines[@]}"})"
+}
+
+if [ -n "${CLAUDE_FORK_DRY_RUN:-}" ]; then
+  printf 'transcript:   %s\n' "${transcript:-<not found>}"
+  printf 'agent_status: %s\n' "$agent_status"
+  printf 'tail:         %s\n' "${tail_state:-<not evaluated>}${tail_kind:+ $tail_kind}${tail_detail:+ $tail_detail}"
+  printf 'decision:     %s (%s)\n' "$decision" "$reason"
+  printf 'herdr pane split --pane %s --direction %s --cwd %s --focus\n' \
+    "$pane_id" "$direction" "$(shq "$cwd")"
+  case "$decision" in
+    fork)
+      printf 'herdr pane run <new-pane> %s\n' "$fork_cmd"
+      ;;
+    wait)
+      printf 'herdr pane run <new-pane> %s\n' "$(printf_cmd "$notice_line")"
+      printf '# re-test the transcript once a second for up to %ss, then either\n' "$wait_seconds"
+      printf 'herdr pane run <new-pane> %s\n' "$fork_cmd"
+      printf '# or, on timeout,\n'
+      printf 'herdr pane run <new-pane> %s\n' "$(refusal_cmd 1)"
+      ;;
+    refuse)
+      printf 'herdr pane run <new-pane> %s\n' "$(refusal_cmd)"
+      ;;
+  esac
+  exit 0
+fi
+
+# The split happens now whatever the guard decides: the pane appearing is how
+# the user knows the keypress registered, and holding it back to go read a file
+# first would make a perfectly good fork feel broken.
 split_json=$(herdr pane split --pane "$pane_id" --direction "$direction" --cwd "$cwd" --focus)
 new_pane_id=$(jq -r '.result.pane.pane_id' <<<"$split_json")
 
-herdr pane run "$new_pane_id" exec claude --resume "$session_id" --fork-session
+timed_out=""
+if [ "$decision" = "wait" ]; then
+  herdr pane run "$new_pane_id" "$(printf_cmd "$notice_line")"
+  deadline=$(( $(date +%s) + wait_seconds ))
+  while :; do
+    read_tail "$transcript"
+    if [ "$tail_state" = "complete" ]; then
+      decision="fork"
+      break
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      decision="refuse"
+      timed_out=1
+      break
+    fi
+    sleep 1
+  done
+fi
+
+if [ "$decision" = "fork" ]; then
+  herdr pane run "$new_pane_id" "$fork_cmd"
+else
+  herdr pane run "$new_pane_id" "$(refusal_cmd "$timed_out")"
+fi

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -19,9 +19,11 @@
 #      One such loss was of text written 6m26s earlier: waiting does not help
 #      here, only answering the question does.
 #
-# One test catches both. Ignoring the sidecar entries a fork drops anyway, the
-# last entry in the transcript must be an `assistant` entry holding a `text`
-# block and no `tool_use` block. Deliberately NOT a whole-file scan for a
+# One test catches both. Ignoring the sidecar entries a fork drops anyway - and
+# the two kinds of `user` entry nobody typed - the last entry in the transcript
+# must be an `assistant` entry holding a `text` block and no `tool_use` block.
+# Both sets are skipped over rather than judged, so the scan keeps walking back
+# to the entry underneath. Deliberately NOT a whole-file scan for a
 # `tool_use` with no `tool_result`: the transcript is a tree, and a branch the
 # user abandoned with an interrupt leaves a dangling `tool_use` behind for good,
 # which would block forking forever. The tail test has no such false positive.
@@ -93,15 +95,56 @@ transcript=$(find "$claude_config/projects" -maxdepth 2 -name "$session_id.jsonl
 # out as "ignore this", never as "the turn is unfinished".
 #
 # Sets tail_state / tail_kind / tail_detail. jq is allowed to fail: the source
-# may be appending to this very file, and a half-written last line should read
-# as "not finished yet" rather than take the script down under `set -e`.
+# may be appending to this very file, and a half-written last line has to come
+# back as `unreadable` - which routes to the wait - rather than take the script
+# down under `set -e`.
 tail_state=""
 tail_kind=""
 tail_detail=""
 read_tail() {
   local out
   out=$(jq -n -r '
-    last(inputs | select(.type == "assistant" or .type == "user"))
+    # Two more entry shapes the scan walks straight past. Both are `user`
+    # entries that a human did not type, and both routinely land last:
+    #
+    #   * the interrupt marker Claude Code writes when ESC is pressed, and
+    #   * the envelope holding the output of a slash command.
+    #
+    # Neither says anything about whether the turn underneath finished, so the
+    # scan keeps walking backwards to the entry beneath and judges *that*. They
+    # are skipped rather than declared complete, and the difference is the whole
+    # point: pressing ESC during a tool call leaves the turn genuinely open, and
+    # a "complete" verdict here would wave through failure mode 2 itself.
+    #
+    # The predicates match the exact shape Claude Code writes - a lone `text`
+    # block equal to the whole marker, or a string that both opens and closes
+    # with one tag pair - so a user message that merely quotes one of these is
+    # still read as a user message.
+    #
+    # Worth the code: of the 307 such entries across the transcripts on this
+    # machine, 67 sit directly on an `assistant` `text`. A fork pressed at any
+    # of those moments used to be refused for no reason. (Such a tail is rare
+    # as the *final* state of a file, because a session interrupted after an
+    # answer usually carried on afterwards - but the guard is evaluated at
+    # whatever instant the key was pressed, not at the end of a session.)
+    def tagged($t):
+      startswith("<" + $t + ">")
+      and (sub("[[:space:]]+$"; "") | endswith("</" + $t + ">"));
+    def unspoken:
+      .type == "user"
+      and ( (.message.content) as $c
+            | if ($c | type) == "string" then
+                ($c | tagged("local-command-stdout"))
+                or ($c | tagged("local-command-caveat"))
+              elif ($c | type) == "array" then
+                ([ $c[].type ] == ["text"])
+                and ( $c[0].text == "[Request interrupted by user]"
+                      or $c[0].text == "[Request interrupted by user for tool use]" )
+              else false
+              end );
+    last(inputs
+         | select(.type == "assistant" or .type == "user")
+         | select(unspoken | not))
     | if . == null then "incomplete\tnone\t"
       else ( (.message.content // []) | if type == "array" then . else [] end ) as $blocks
         | if .type != "assistant" then
@@ -138,6 +181,14 @@ else
   read_tail "$transcript"
   if [ "$tail_state" = "complete" ]; then
     reason="the source session's last turn is complete"
+  elif [ "$tail_kind" = "unreadable" ]; then
+    # A last line that will not parse means the source process is writing to the
+    # file at this very instant, which is itself evidence the turn is in flight.
+    # So this is the wait case no matter what the pane status claims: refusing on
+    # a transient parse failure would turn a race we can win into a hard stop.
+    # A transcript that is genuinely damaged still refuses, one timeout later.
+    decision="wait"
+    reason="transcript did not parse - the source looks like it is mid-write"
   elif [ "$agent_status" = "idle" ]; then
     # Nothing is running, so nothing is going to finish the turn on its own.
     # Waiting here would only postpone the same refusal by wait_seconds.
@@ -166,11 +217,34 @@ printf_cmd() {
 refusal_lines=()
 build_refusal() {
   local timed_out="${1:-}"
-  refusal_lines=(
-    ""
-    "Fork not started: the source session's last turn is incomplete."
-    ""
-  )
+  refusal_lines=("")
+
+  # A transcript that never became readable is a different complaint from a turn
+  # that never finished, and wants a different message: nothing is known about
+  # the turn, and the file itself is the thing to go and look at.
+  if [ "$tail_kind" = "unreadable" ]; then
+    refusal_lines+=("Fork not started: the source session's transcript could not be read.")
+    refusal_lines+=("")
+    if [ -n "$timed_out" ]; then
+      refusal_lines+=("  Re-read it for ${wait_seconds}s and it never parsed. A file merely being appended")
+      refusal_lines+=("  to comes right within a second, so this one looks damaged:")
+    else
+      refusal_lines+=("  Its last line does not parse - truncated, or the file is damaged:")
+    fi
+    refusal_lines+=("  $transcript")
+    refusal_lines+=("")
+    refusal_lines+=("Without reading it there is no way to tell whether the last turn finished, so")
+    refusal_lines+=("forking might silently drop the tail of the conversation.")
+    refusal_lines+=("")
+    refusal_lines+=("To fork anyway, paste:")
+    refusal_lines+=("")
+    refusal_lines+=("  claude --resume $(shq "$session_id") --fork-session")
+    refusal_lines+=("")
+    return
+  fi
+
+  refusal_lines+=("Fork not started: the source session's last turn is incomplete.")
+  refusal_lines+=("")
   if [ -n "$timed_out" ]; then
     refusal_lines+=("  Waited ${wait_seconds}s for the turn to finish and it did not.")
     refusal_lines+=("")
@@ -200,10 +274,6 @@ build_refusal() {
     assistant)
       refusal_lines+=("  The source's last entry is an assistant ${tail_detail:-non-text} block, so the turn")
       refusal_lines+=("  has not been closed out with an answer.")
-      ;;
-    unreadable)
-      refusal_lines+=("  The transcript could not be parsed - most likely it is being written to")
-      refusal_lines+=("  right now.")
       ;;
     *)
       refusal_lines+=("  The transcript has no finished assistant turn at its end.")

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -19,11 +19,20 @@
 #
 # Both harms need an assistant turn that was started and never finished, so that
 # is the only thing the guard holds a fork back for. A transcript whose last
-# entry is a *user* entry is not that case, whatever put it there - a typed
-# message, a slash command, `!` bash mode, a background agent reporting in.
-# Nothing needs rewinding and no written answer is at risk; the fork just
+# entry is a *user* entry is usually not that case, whatever put it there - a
+# typed message, a slash command, `!` bash mode, a background agent reporting
+# in. Nothing needs rewinding and no written answer is at risk; the fork just
 # answers it. Letting those through is what keeps the guard from crying wolf,
 # and it is by far the commonest tail there is.
+#
+# "Usually", because a user entry can also land *on top of* a tool call that is
+# still open - the tail then looks like an ordinary message while the turn
+# underneath is the unfinished kind, and forking rewinds past it after all. So
+# the tail test also carries the calls still outstanding on the current turn,
+# and judges such a tail as the open call instead. Rare but real: measured over
+# the transcripts on this machine it happens in roughly one tool call in ten
+# thousand, and every AskUserQuestion left pending - some for the better part of
+# an hour - had nothing written under it at all.
 #
 # Deliberately NOT a whole-file scan for a `tool_use` with no `tool_result`: the
 # transcript is a tree, and a branch the user abandoned with an interrupt leaves
@@ -126,17 +135,43 @@ read_tail() {
       and ( ((.message.content[0]? | .text?) // "") as $t
             | $t == "[Request interrupted by user]"
               or $t == "[Request interrupted by user for tool use]" );
-    last(inputs
-         | select(.type == "assistant" or .type == "user")
-         | select(marker | not))
+    def blocks: (.message.content // []) | if type == "array" then . else [] end;
+    # One forward pass keeps two things: the last entry that counts as the tail,
+    # and the tool calls still outstanding on the turn the tail belongs to.
+    # `pending` is emptied at every assistant entry holding a `text` block, so it
+    # only ever describes the turn in progress - which is what keeps this a tail
+    # test rather than the whole-file tree scan ruled out above. Walking forward
+    # rather than backwards is what lets it stay streaming: `pending` holds one
+    # small record per unanswered call, never the file.
+    reduce ( inputs | select(.type == "assistant" or .type == "user") ) as $e
+      ( { last: null, pending: [] };
+        ( $e | blocks ) as $b
+        | ( if $e.type == "assistant"
+               and ( [ $b[]? | select(.type? == "text") ] | length ) > 0
+            then .pending = [] else . end )
+        | .pending += [ $b[]? | select(.type? == "tool_use")
+                        | { id: (.id? // ""), name: (.name? // "") } ]
+        | ( [ $b[]? | select(.type? == "tool_result") | .tool_use_id? // "" ] ) as $done
+        | .pending = [ .pending[] | select( ([.id] - $done) | length > 0 ) ]
+        | ( if ($e | marker) then . else .last = $e end ) )
+    | . as $state
+    | $state.last
     | if . == null then "empty\t"
-      else ( (.message.content // []) | if type == "array" then . else [] end ) as $b
+      else blocks as $b
         | if .type != "assistant" then
-            if ( [ $b[]? | select(.type? == "tool_result") ] | length ) > 0
-            then "tool_result\t" else "message\t" end
+            if ( [ $b[]? | select(.type? == "tool_result") ] | length ) > 0 then
+              "tool_result\t"
+            elif ( $state.pending | length ) > 0 then
+              # A user entry landed on top of a tool call that is still open -
+              # a skill body being injected, a background agent reporting in, a
+              # message typed while the turn ran. The tail looks like a plain
+              # user message, but the turn underneath is the unfinished kind,
+              # and forking would rewind past it. Judge it as that instead.
+              "tool_use\t" + ($state.pending[0].name)
+            else "message\t" end
           else
-            ( [ $b[]? | select(.type? == "tool_use") ] | first ) as $pending
-            | if $pending != null then "tool_use\t" + ($pending.name? // "")
+            ( [ $b[]? | select(.type? == "tool_use") ] | first ) as $open
+            | if $open != null then "tool_use\t" + ($open.name? // "")
               elif ( [ $b[]? | select(.type? == "text") ] | length ) > 0 then "complete\t"
               else "partial\t" + ( ( [ $b[]? | .type? ] | first ) // "" )
               end

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -5,10 +5,8 @@
 # https://gist.github.com/miyagawa/cb1a9f6c8695d1219efba0c66d5f78f7
 #
 # The fork point is not ours to pick. `claude --resume <id> --fork-session`
-# starts from whatever the source session's transcript happens to hold on disk
-# at the instant the new process reads it, so a source that is mid-turn at that
-# instant yields a fork whose conversation is quietly truncated and whose last
-# answer is simply missing. Two ways that happens in practice:
+# starts from whatever the source session's transcript holds on disk at the
+# instant the new process reads it, and there are two ways that lands badly:
 #
 #   1. A race. The key was pressed while the source was still working, so the
 #      answer had not been written out yet. A few seconds of waiting fixes it.
@@ -19,22 +17,28 @@
 #      One such loss was of text written 6m26s earlier: waiting does not help
 #      here, only answering the question does.
 #
-# One test catches both. Ignoring the sidecar entries a fork drops anyway - and
-# the two kinds of `user` entry nobody typed - the last entry in the transcript
-# must be an `assistant` entry holding a `text` block and no `tool_use` block.
-# Both sets are skipped over rather than judged, so the scan keeps walking back
-# to the entry underneath. Deliberately NOT a whole-file scan for a
-# `tool_use` with no `tool_result`: the transcript is a tree, and a branch the
-# user abandoned with an interrupt leaves a dangling `tool_use` behind for good,
-# which would block forking forever. The tail test has no such false positive.
+# Both harms need an assistant turn that was started and never finished, so that
+# is the only thing the guard holds a fork back for. A transcript whose last
+# entry is a *user* entry is not that case, whatever put it there - a typed
+# message, a slash command, `!` bash mode, a background agent reporting in.
+# Nothing needs rewinding and no written answer is at risk; the fork just
+# answers it. Letting those through is what keeps the guard from crying wolf,
+# and it is by far the commonest tail there is.
 #
-# The new pane is the only channel that reaches the user - toast notifications
-# are disabled on this machine, and whether a plugin action's stderr surfaces
-# anywhere at all is unknown - so the guard reports itself by writing into it.
+# Deliberately NOT a whole-file scan for a `tool_use` with no `tool_result`: the
+# transcript is a tree, and a branch the user abandoned with an interrupt leaves
+# a dangling `tool_use` behind for good, which would block forking forever. The
+# tail test has no such false positive.
+#
+# The guard reports itself by writing into the new pane. Toast notifications are
+# disabled on this machine, and while `herdr plugin log list` does record each
+# action's stdout and stderr, a log you have to go and query does not reach
+# anyone at the moment it matters.
 #
 # Set CLAUDE_FORK_NO_WAIT=1 to skip the guard and fork immediately.
 # Set CLAUDE_FORK_DRY_RUN=1 to print the decision and the herdr calls it implies
 # without splitting or running anything.
+# Set CLAUDE_FORK_WAIT_SECONDS to change how long an in-flight turn is given.
 set -euo pipefail
 
 direction="${1:-right}"
@@ -44,6 +48,11 @@ case "$direction" in
     echo "usage: fork.sh [right|down]" >&2
     exit 1
     ;;
+esac
+
+wait_seconds="${CLAUDE_FORK_WAIT_SECONDS:-30}"
+case "$wait_seconds" in
+  ''|*[!0-9]*) wait_seconds=30 ;;
 esac
 
 pane_id="${HERDR_PANE_ID:?HERDR_PANE_ID not set — run this action from a pane context}"
@@ -81,92 +90,64 @@ fork_cmd="exec claude --resume $(shq "$session_id") --fork-session"
 claude_config="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 transcript=$(find "$claude_config/projects" -maxdepth 2 -name "$session_id.jsonl" 2>/dev/null | head -1) || true
 
-# --- the completed-turn test -------------------------------------------------
-# Only `assistant` and `user` entries sit *on* the conversation. Every other
-# .type is a sidecar hanging off it that a fork does not carry: system/*
-# (turn_duration, stop_hook_summary, away_summary, informational), attachment,
-# last-prompt, file-history-snapshot, ai-title, mode, permission-mode,
-# atis-latch, pr-link, queue-operation and more. Whitelisting the two rather
-# than blacklisting the sidecars is deliberate, and load-bearing: of the 138
-# cleanly-finished transcripts on this machine, 112 have a *non*-`system`
-# sidecar sitting after their final assistant text, so a blacklist that only
-# skipped `system` would refuse four good forks out of five. The sidecar set
-# also grows with Claude Code releases, and an unfamiliar new .type has to fall
-# out as "ignore this", never as "the turn is unfinished".
+# --- read the tail -----------------------------------------------------------
+# Only `assistant` and `user` entries sit *on* the conversation; every other
+# .type is a sidecar hanging off it that a fork does not carry (system/*,
+# attachment, last-prompt, file-history-snapshot, ai-title, mode, pr-link,
+# queue-operation and a growing list besides). Whitelisting the two rather than
+# blacklisting the sidecars is deliberate, and load-bearing: sidecars trail the
+# final assistant text in the great majority of cleanly finished transcripts, so
+# a blacklist would refuse most good forks outright. It also fails in the right
+# direction, since a .type added by a future release falls out as "ignore this"
+# rather than as "the turn is unfinished".
 #
-# Sets tail_state / tail_kind / tail_detail. jq is allowed to fail: the source
-# may be appending to this very file, and a half-written last line has to come
-# back as `unreadable` - which routes to the wait - rather than take the script
-# down under `set -e`.
-tail_state=""
+# The interrupt marker Claude Code writes when ESC is pressed is skipped too, on
+# the same keep-walking-backwards footing rather than being judged itself. It
+# says nothing about the turn underneath, and what is underneath is usually the
+# tool result from the call that got interrupted - a turn still in flight, and
+# exactly what the guard should be waiting on. Judging the marker itself would
+# read as a plain user tail and fork straight past that.
+#
+# Sets tail_kind (one of complete / empty / message / tool_result / tool_use /
+# partial / unreadable) and tail_detail. jq is allowed to fail: the source may
+# be appending to this very file, and a half-written last line has to come back
+# as `unreadable` - which routes to the wait - rather than take the script down
+# under `set -e`. Every array index is `?`-guarded so a content block that is
+# not an object cannot throw and be misreported as a torn file.
 tail_kind=""
 tail_detail=""
 read_tail() {
   local out
   out=$(jq -n -r '
-    # Two more entry shapes the scan walks straight past. Both are `user`
-    # entries that a human did not type, and both routinely land last:
-    #
-    #   * the interrupt marker Claude Code writes when ESC is pressed, and
-    #   * the envelope holding the output of a slash command.
-    #
-    # Neither says anything about whether the turn underneath finished, so the
-    # scan keeps walking backwards to the entry beneath and judges *that*. They
-    # are skipped rather than declared complete, and the difference is the whole
-    # point: pressing ESC during a tool call leaves the turn genuinely open, and
-    # a "complete" verdict here would wave through failure mode 2 itself.
-    #
-    # The predicates match the exact shape Claude Code writes - a lone `text`
-    # block equal to the whole marker, or a string that both opens and closes
-    # with one tag pair - so a user message that merely quotes one of these is
-    # still read as a user message.
-    #
-    # Worth the code: of the 307 such entries across the transcripts on this
-    # machine, 67 sit directly on an `assistant` `text`. A fork pressed at any
-    # of those moments used to be refused for no reason. (Such a tail is rare
-    # as the *final* state of a file, because a session interrupted after an
-    # answer usually carried on afterwards - but the guard is evaluated at
-    # whatever instant the key was pressed, not at the end of a session.)
-    def tagged($t):
-      startswith("<" + $t + ">")
-      and (sub("[[:space:]]+$"; "") | endswith("</" + $t + ">"));
-    def unspoken:
+    def marker:
       .type == "user"
-      and ( (.message.content) as $c
-            | if ($c | type) == "string" then
-                ($c | tagged("local-command-stdout"))
-                or ($c | tagged("local-command-caveat"))
-              elif ($c | type) == "array" then
-                ([ $c[].type ] == ["text"])
-                and ( $c[0].text == "[Request interrupted by user]"
-                      or $c[0].text == "[Request interrupted by user for tool use]" )
-              else false
-              end );
+      and ((.message.content | type) == "array")
+      and ([ .message.content[]? | .type? ] == ["text"])
+      and ( ((.message.content[0]? | .text?) // "") as $t
+            | $t == "[Request interrupted by user]"
+              or $t == "[Request interrupted by user for tool use]" );
     last(inputs
          | select(.type == "assistant" or .type == "user")
-         | select(unspoken | not))
-    | if . == null then "incomplete\tnone\t"
-      else ( (.message.content // []) | if type == "array" then . else [] end ) as $blocks
+         | select(marker | not))
+    | if . == null then "empty\t"
+      else ( (.message.content // []) | if type == "array" then . else [] end ) as $b
         | if .type != "assistant" then
-            "incomplete\tuser\t"
-            + ( if ( [ $blocks[] | select(.type == "tool_result") ] | length ) > 0
-                then "tool_result" else "message" end )
+            if ( [ $b[]? | select(.type? == "tool_result") ] | length ) > 0
+            then "tool_result\t" else "message\t" end
           else
-            ( [ $blocks[] | select(.type == "tool_use") ] | first ) as $pending
-            | if $pending != null then "incomplete\ttool_use\t" + ($pending.name // "")
-              elif ( [ $blocks[] | select(.type == "text") ] | length ) > 0 then "complete\t\t"
-              else "incomplete\tassistant\t" + ( ( [ $blocks[].type ] | first ) // "" )
+            ( [ $b[]? | select(.type? == "tool_use") ] | first ) as $pending
+            | if $pending != null then "tool_use\t" + ($pending.name? // "")
+              elif ( [ $b[]? | select(.type? == "text") ] | length ) > 0 then "complete\t"
+              else "partial\t" + ( ( [ $b[]? | .type? ] | first ) // "" )
               end
           end
       end
   ' "$1" 2>/dev/null) || out=""
-  [ -n "$out" ] || out=$(printf 'incomplete\tunreadable\t')
-  IFS=$'\t' read -r tail_state tail_kind tail_detail <<<"$out" || true
-  :
+  [ -n "$out" ] || out=$'unreadable\t'
+  IFS=$'\t' read -r tail_kind tail_detail <<<"$out" || true
 }
 
 # --- decide ------------------------------------------------------------------
-wait_seconds=30
 decision="fork"
 reason=""
 
@@ -179,25 +160,45 @@ elif [ -z "$transcript" ]; then
   reason="no transcript found under $claude_config/projects"
 else
   read_tail "$transcript"
-  if [ "$tail_state" = "complete" ]; then
-    reason="the source session's last turn is complete"
-  elif [ "$tail_kind" = "unreadable" ]; then
-    # A last line that will not parse means the source process is writing to the
-    # file at this very instant, which is itself evidence the turn is in flight.
-    # So this is the wait case no matter what the pane status claims: refusing on
-    # a transient parse failure would turn a race we can win into a hard stop.
-    # A transcript that is genuinely damaged still refuses, one timeout later.
-    decision="wait"
-    reason="transcript did not parse - the source looks like it is mid-write"
-  elif [ "$agent_status" = "idle" ]; then
-    # Nothing is running, so nothing is going to finish the turn on its own.
-    # Waiting here would only postpone the same refusal by wait_seconds.
-    decision="refuse"
-    reason="last turn is incomplete and the source pane is idle"
-  else
-    decision="wait"
-    reason="last turn is incomplete and the source pane is $agent_status"
-  fi
+  case "$tail_kind" in
+    complete)
+      reason="the last turn is finished"
+      ;;
+    message)
+      reason="the last entry is a user message, which the fork will answer itself"
+      ;;
+    empty)
+      reason="the transcript holds no conversation to be mid-way through"
+      ;;
+    tool_use)
+      if [ "$agent_status" = "idle" ]; then
+        # A tool call with no result, and nothing running to produce one. Unlike
+        # the other open-turn tails this will not resolve on its own, so waiting
+        # would only postpone the same refusal by wait_seconds.
+        decision="refuse"
+        reason="an unanswered ${tail_detail:-tool} call, and the source pane is idle"
+      else
+        decision="wait"
+        reason="an unanswered ${tail_detail:-tool} call, and the source pane is $agent_status"
+      fi
+      ;;
+    unreadable)
+      # A last line that will not parse means the source process is writing to
+      # the file at this very instant, which is itself evidence the turn is in
+      # flight. So this is the wait case no matter what the pane status claims:
+      # refusing on a transient parse failure would turn a race we can win into
+      # a hard stop. A genuinely damaged file still refuses, one timeout later.
+      decision="wait"
+      reason="the transcript did not parse - the source looks like it is mid-write"
+      ;;
+    *)
+      # tool_result, or an assistant turn that has only got as far as thinking.
+      # Both mean the answer is still being written - this is the race, and the
+      # case waiting was built for.
+      decision="wait"
+      reason="the turn is still in flight ($tail_kind)"
+      ;;
+  esac
 fi
 
 # --- what the guard says in the pane -----------------------------------------
@@ -214,100 +215,86 @@ printf_cmd() {
   printf '%s' "$cmd"
 }
 
-refusal_lines=()
-build_refusal() {
-  local timed_out="${1:-}"
-  refusal_lines=("")
-
-  # A transcript that never became readable is a different complaint from a turn
-  # that never finished, and wants a different message: nothing is known about
-  # the turn, and the file itself is the thing to go and look at.
-  if [ "$tail_kind" = "unreadable" ]; then
-    refusal_lines+=("Fork not started: the source session's transcript could not be read.")
-    refusal_lines+=("")
-    if [ -n "$timed_out" ]; then
-      refusal_lines+=("  Re-read it for ${wait_seconds}s and it never parsed. A file merely being appended")
-      refusal_lines+=("  to comes right within a second, so this one looks damaged:")
-    else
-      refusal_lines+=("  Its last line does not parse - truncated, or the file is damaged:")
-    fi
-    refusal_lines+=("  $transcript")
-    refusal_lines+=("")
-    refusal_lines+=("Without reading it there is no way to tell whether the last turn finished, so")
-    refusal_lines+=("forking might silently drop the tail of the conversation.")
-    refusal_lines+=("")
-    refusal_lines+=("To fork anyway, paste:")
-    refusal_lines+=("")
-    refusal_lines+=("  claude --resume $(shq "$session_id") --fork-session")
-    refusal_lines+=("")
-    return
-  fi
-
-  refusal_lines+=("Fork not started: the source session's last turn is incomplete.")
-  refusal_lines+=("")
-  if [ -n "$timed_out" ]; then
-    refusal_lines+=("  Waited ${wait_seconds}s for the turn to finish and it did not.")
-    refusal_lines+=("")
-  fi
-  case "$tail_kind" in
-    tool_use)
-      if [ "$tail_detail" = "AskUserQuestion" ]; then
-        refusal_lines+=("  The source is waiting on a question nobody has answered yet. Answer it in")
-        refusal_lines+=("  the source pane first and the fork will carry the whole conversation.")
-      elif [ -n "$tail_detail" ]; then
-        refusal_lines+=("  The source is sitting on a $tail_detail tool call with no result yet, so the")
-        refusal_lines+=("  turn it belongs to is still open.")
-      else
-        refusal_lines+=("  The source is sitting on a tool call with no result yet, so the turn it")
-        refusal_lines+=("  belongs to is still open.")
-      fi
-      ;;
-    user)
-      if [ "$tail_detail" = "tool_result" ]; then
-        refusal_lines+=("  The source's last entry is a tool result, so the turn that asked for it has")
-        refusal_lines+=("  not been answered yet.")
-      else
-        refusal_lines+=("  The source's last entry is a message to the assistant that has not been")
-        refusal_lines+=("  answered yet.")
-      fi
-      ;;
-    assistant)
-      refusal_lines+=("  The source's last entry is an assistant ${tail_detail:-non-text} block, so the turn")
-      refusal_lines+=("  has not been closed out with an answer.")
-      ;;
-    *)
-      refusal_lines+=("  The transcript has no finished assistant turn at its end.")
-      ;;
-  esac
-  refusal_lines+=("")
-  refusal_lines+=("Forking now would rewind past that unfinished turn, so the tail of the")
-  refusal_lines+=("conversation - including any answer already written inside it - would not")
-  refusal_lines+=("carry over.")
-  refusal_lines+=("")
-  refusal_lines+=("To fork anyway, paste:")
-  refusal_lines+=("")
-  refusal_lines+=("  claude --resume $(shq "$session_id") --fork-session")
-  refusal_lines+=("")
-}
-
 # zsh echoes a command line before running it, and the refusal is long enough
 # that its own quoted source would push the message off a short pane. Clear
 # first so what is left on screen is the message and a prompt.
 refusal_cmd() {
-  build_refusal "${1:-}"
-  printf 'clear; %s' "$(printf_cmd ${refusal_lines[@]+"${refusal_lines[@]}"})"
+  local timed_out="${1:-}"
+  local lines
+  lines=("")
+  if [ "$tail_kind" = "unreadable" ]; then
+    # Distinct from the mid-turn refusal on purpose: nothing is known about the
+    # turn here, and the file itself is the thing to go and look at.
+    if [ -e "$transcript" ]; then
+      lines+=("Fork not started: the source session's transcript could not be read.")
+      lines+=("")
+      lines+=("  Its last line still would not parse after ${wait_seconds}s, so the file looks")
+      lines+=("  damaged rather than merely mid-write:")
+    else
+      lines+=("Fork not started: the source session's transcript has gone.")
+      lines+=("")
+      lines+=("  It disappeared while the guard was watching it:")
+    fi
+    lines+=("  $transcript")
+    lines+=("")
+    lines+=("Without reading it there is no way to tell whether the last turn finished, so")
+    lines+=("forking might silently drop the tail of the conversation.")
+  else
+    lines+=("Fork not started: the source session is still mid-turn.")
+    lines+=("")
+    if [ -n "$timed_out" ]; then
+      lines+=("  Waited ${wait_seconds}s for the turn to finish and it did not.")
+      lines+=("")
+    fi
+    case "$tail_kind" in
+      tool_use)
+        if [ "$tail_detail" = "AskUserQuestion" ]; then
+          # The one thing here the user could not have guessed, and the one they
+          # can actually act on: the source is blocked on them, not on the model.
+          lines+=("  The source is waiting on a question nobody has answered. Answer it in the")
+          lines+=("  source pane first and the fork will carry the whole conversation.")
+        else
+          lines+=("  Its last entry is a ${tail_detail:-tool} call with no result yet.")
+        fi
+        ;;
+      tool_result)
+        lines+=("  Its last entry is a tool result the assistant has not replied to yet.")
+        ;;
+      *)
+        lines+=("  Its last entry is ${tail_detail:-partial} output, not a finished answer.")
+        ;;
+    esac
+    lines+=("")
+    lines+=("Forking now would rewind past that unfinished turn, so the tail of the")
+    lines+=("conversation - including any answer already written inside it - would not")
+    lines+=("carry over.")
+  fi
+  lines+=("")
+  lines+=("To fork anyway, paste:")
+  lines+=("")
+  lines+=("  claude --resume $(shq "$session_id") --fork-session")
+  lines+=("")
+  printf 'clear; %s' "$(printf_cmd ${lines[@]+"${lines[@]}"})"
 }
+
+# The new pane is by construction the source pane's neighbour in $direction, so
+# focus can be handed to it without knowing its id.
+focus_new_pane() {
+  herdr pane focus --pane "$pane_id" --direction "$direction" >/dev/null
+}
+focus_cmd="herdr pane focus --pane $(shq "$pane_id") --direction $direction"
 
 if [ -n "${CLAUDE_FORK_DRY_RUN:-}" ]; then
   printf 'transcript:   %s\n' "${transcript:-<not found>}"
   printf 'agent_status: %s\n' "$agent_status"
-  printf 'tail:         %s\n' "${tail_state:-<not evaluated>}${tail_kind:+ $tail_kind}${tail_detail:+ $tail_detail}"
+  printf 'tail:         %s\n' "${tail_kind:-<not evaluated>}${tail_detail:+ $tail_detail}"
   printf 'decision:     %s (%s)\n' "$decision" "$reason"
-  printf 'herdr pane split --pane %s --direction %s --cwd %s --focus\n' \
+  printf 'herdr pane split --pane %s --direction %s --cwd %s --no-focus\n' \
     "$pane_id" "$direction" "$(shq "$cwd")"
   case "$decision" in
     fork)
       printf 'herdr pane run <new-pane> %s\n' "$fork_cmd"
+      printf '%s\n' "$focus_cmd"
       ;;
     wait)
       printf 'herdr pane run <new-pane> %s\n' "$(printf_cmd "$notice_line")"
@@ -315,9 +302,11 @@ if [ -n "${CLAUDE_FORK_DRY_RUN:-}" ]; then
       printf 'herdr pane run <new-pane> %s\n' "$fork_cmd"
       printf '# or, on timeout,\n'
       printf 'herdr pane run <new-pane> %s\n' "$(refusal_cmd 1)"
+      printf '%s\n' "$focus_cmd"
       ;;
     refuse)
       printf 'herdr pane run <new-pane> %s\n' "$(refusal_cmd)"
+      printf '%s\n' "$focus_cmd"
       ;;
   esac
   exit 0
@@ -326,7 +315,13 @@ fi
 # The split happens now whatever the guard decides: the pane appearing is how
 # the user knows the keypress registered, and holding it back to go read a file
 # first would make a perfectly good fork feel broken.
-split_json=$(herdr pane split --pane "$pane_id" --direction "$direction" --cwd "$cwd" --focus)
+#
+# It is left unfocused, though. On the waiting path this pane can sit here for
+# wait_seconds with a live shell prompt in it, and `pane run` sends its text to
+# whatever is already on that command line - so anything typed into a focused
+# prompt meanwhile would end up with the fork command glued onto the end of it.
+# Focus is handed over at the moment the pane has something to show instead.
+split_json=$(herdr pane split --pane "$pane_id" --direction "$direction" --cwd "$cwd" --no-focus)
 new_pane_id=$(jq -r '.result.pane.pane_id' <<<"$split_json")
 
 timed_out=""
@@ -335,10 +330,12 @@ if [ "$decision" = "wait" ]; then
   deadline=$(( $(date +%s) + wait_seconds ))
   while :; do
     read_tail "$transcript"
-    if [ "$tail_state" = "complete" ]; then
-      decision="fork"
-      break
-    fi
+    case "$tail_kind" in
+      complete|message|empty)
+        decision="fork"
+        break
+        ;;
+    esac
     if [ "$(date +%s)" -ge "$deadline" ]; then
       decision="refuse"
       timed_out=1
@@ -353,3 +350,4 @@ if [ "$decision" = "fork" ]; then
 else
   herdr pane run "$new_pane_id" "$(refusal_cmd "$timed_out")"
 fi
+focus_new_pane

--- a/.config/herdr/plugins/claude-fork/fork.sh
+++ b/.config/herdr/plugins/claude-fork/fork.sh
@@ -34,10 +34,13 @@
 # thousand, and every AskUserQuestion left pending - some for the better part of
 # an hour - had nothing written under it at all.
 #
-# Deliberately NOT a whole-file scan for a `tool_use` with no `tool_result`: the
-# transcript is a tree, and a branch the user abandoned with an interrupt leaves
-# a dangling `tool_use` behind for good, which would block forking forever. The
-# tail test has no such false positive.
+# Deliberately NOT a whole-file scan for a `tool_use` with no `tool_result`.
+# Claude Code does close every call it opens - across every transcript on this
+# machine not one is left dangling, synthetic results for interrupted calls
+# included - so such a scan would buy nothing on a healthy transcript. What it would cost is recoverability: one call left open by a
+# crash, or by some future change to that behaviour, would block every fork for
+# the rest of the session. Bounding the test to the turn in progress means an
+# anomaly like that stops mattering as soon as one more answer is written.
 #
 # The guard reports itself by writing into the new pane. Toast notifications are
 # disabled on this machine, and while `herdr plugin log list` does record each
@@ -60,8 +63,15 @@ case "$direction" in
 esac
 
 wait_seconds="${CLAUDE_FORK_WAIT_SECONDS:-30}"
+# Anything that is not a plain number falls back to the default - and so does
+# anything absurdly large. `$(( $(date +%s) + w ))` overflows on a big enough
+# value and yields a deadline in the far future rather than an error, which the
+# poll loop then never reaches: the action never returns, and the pane is left
+# sitting on the waiting notice for good. Five digits is already far past any
+# useful turn, so cap it by length and never do arithmetic on the raw value.
 case "$wait_seconds" in
   ''|*[!0-9]*) wait_seconds=30 ;;
+  ?????*)      wait_seconds=30 ;;
 esac
 
 pane_id="${HERDR_PANE_ID:?HERDR_PANE_ID not set — run this action from a pane context}"
@@ -112,30 +122,39 @@ transcript=$(find "$claude_config/projects" -maxdepth 2 -name "$session_id.jsonl
 #
 # The interrupt marker Claude Code writes when ESC is pressed is skipped too, on
 # the same keep-walking-backwards footing rather than being judged itself. It
-# says nothing about the turn underneath, and what is underneath is usually the
-# tool result from the call that got interrupted - a turn still in flight, and
-# exactly what the guard should be waiting on. Judging the marker itself would
-# read as a plain user tail and fork straight past that.
+# says nothing about the turn underneath. What is underneath is a plain user
+# entry more often than not, so this is not the majority case; the one that
+# matters is the sizeable minority sitting on the tool result from the call that
+# got interrupted, because those are exactly the markers where skipping changes
+# the answer - a turn still in flight, and one the guard should be waiting on.
+# Judging the marker itself would read as a plain user tail and fork past those.
 #
 # Sets tail_kind (one of complete / empty / message / tool_result / tool_use /
 # partial / unreadable) and tail_detail. jq is allowed to fail: the source may
 # be appending to this very file, and a half-written last line has to come back
 # as `unreadable` - which routes to the wait - rather than take the script down
-# under `set -e`. Every array index is `?`-guarded so a content block that is
-# not an object cannot throw and be misreported as a torn file.
+# under `set -e`. Reads of the content and of the blocks inside it are all
+# `?`-guarded, so neither a `.message` that is not an object nor a content block
+# that is not an object can throw and be misreported as a torn file.
 tail_kind=""
 tail_detail=""
 read_tail() {
   local out
   out=$(jq -n -r '
+    # `.message` is not always an object - a malformed entry can carry a bare
+    # string - so every read of the content goes through one guarded accessor.
+    # It has to yield a value rather than `empty`: an update expression that
+    # produces `empty` makes `reduce` below collapse its whole accumulator to
+    # null, so a plain `?` here would trade a wrong verdict for a broken one.
+    def content: .message?.content? // null;
     def marker:
       .type == "user"
-      and ((.message.content | type) == "array")
-      and ([ .message.content[]? | .type? ] == ["text"])
-      and ( ((.message.content[0]? | .text?) // "") as $t
+      and ((content | type) == "array")
+      and ([ content[]? | .type? ] == ["text"])
+      and ( ((content[0]? | .text?) // "") as $t
             | $t == "[Request interrupted by user]"
               or $t == "[Request interrupted by user for tool use]" );
-    def blocks: (.message.content // []) | if type == "array" then . else [] end;
+    def blocks: content | if type == "array" then . else [] end;
     # One forward pass keeps two things: the last entry that counts as the tail,
     # and the tool calls still outstanding on the turn the tail belongs to.
     # `pending` is emptied at every assistant entry holding a `text` block, so it
@@ -230,6 +249,13 @@ else
       # tool_result, or an assistant turn that has only got as far as thinking.
       # Both mean the answer is still being written - this is the race, and the
       # case waiting was built for.
+      #
+      # Note these deliberately do NOT consult agent_status the way `tool_use`
+      # above does, so a dead session stalls for wait_seconds before refusing.
+      # That is the intended trade: agent_status flickers to idle between the
+      # calls of a running tool loop, and an idle->fork shortcut here would fork
+      # straight into the middle of one. An unanswered `tool_use` can take the
+      # shortcut because nothing but the user can ever close it.
       decision="wait"
       reason="the turn is still in flight ($tail_kind)"
       ;;


### PR DESCRIPTION
Forking with `prefix+ctrl+right` sometimes produced a fork whose conversation was
missing the source's last answer. It was not a display artifact — the answer was
genuinely absent from the fork's context.

`fork.sh` never chose a fork point. `claude --resume <id> --fork-session` starts
from whatever the source's transcript happens to hold on disk at the instant the
new process reads it, so a source that was mid-turn at that instant yielded a
quietly truncated fork.

# What the transcripts show

Comparing every fork on this machine against its source — 74 files, 19 roots,
so 55 real fork events — 42 landed on a completed answer. Two modes account for
the losses:

1. **A race.** The key was pressed while the source was still working, so the
   answer had not been written out yet. In the observed case the source finished
   its turn 16s after the fork read the file. Seconds of waiting fixes it.

2. **An unanswered tool call.** The source sat on a `tool_use` with no
   `tool_result` — in both observed cases an `AskUserQuestion` nobody had
   answered. The API cannot accept a `tool_use` without its matching
   `tool_result`, so the fork has to rewind past that whole turn, and any `text`
   the model emitted in the same turn is discarded with it.

The second one is the nastier of the two, because waiting does not help. In
`779c0f65` the lost text had been written **6m26s** before the fork read the
file, and the question was not answered until two minutes after. The text was
a retraction — "先ほどの私の…は誤りでした。撤回します。" — so the fork started
from the mistaken premise the source had already corrected.

# What the guard does

One tail test catches both. Ignoring the sidecar entries a fork drops anyway,
the last conversation entry decides:

| tail | decision |
|---|---|
| assistant `text` — turn finished | fork |
| user message — typed, slash command, `!` bash mode, task notification | fork |
| no conversation entries | fork |
| user `tool_result`, or assistant `thinking` — turn in flight | wait, then refuse on timeout |
| assistant `tool_use` with no result | idle → refuse; working → wait, then refuse |
| transcript will not parse | wait, then refuse on timeout |

The split still happens first on every path — the pane appearing is how you know
the keypress registered — but it is created with `--no-focus` and focus moves
only when the final command is sent, so a prompt cannot sit focused during the
wait and collect keystrokes that then get the fork command appended to them.

Refusals are written into the new pane. Toasts are off, and a plugin action's
stderr only reaches `herdr plugin log list`, which does not reach anyone at the
moment it matters. An `AskUserQuestion` refusal says to answer it in the source
pane first; every refusal ends with the `claude --resume … --fork-session` line
so forking anyway is one paste.

`CLAUDE_FORK_NO_WAIT=1` skips the guard. `CLAUDE_FORK_DRY_RUN=1` prints the
decision and the `herdr` calls it implies without splitting anything.
`CLAUDE_FORK_WAIT_SECONDS` overrides the 30s.

# Things that were measured rather than assumed

- **Sidecars are whitelisted out, not blacklisted.** Only `assistant` and `user`
  entries sit on the conversation. Of the cleanly-finished transcripts here, 112
  of 138 have a *non-`system`* sidecar after their final assistant text, so a
  blacklist that skipped only `system` would have refused four good forks in five.
  There are 16 sidecar `.type`s and the set grows with releases, so an unfamiliar
  new one has to fall out as "ignore this", never as "the turn is unfinished".

- **A user tail is not unconditionally safe.** A user entry landing on top of a
  still-open tool call would read as a finished turn and fork past it. Rare —
  one occurrence in 10,458 tool-call windows, a Skill body injected between
  parallel calls and their results — and the `AskUserQuestion` version does not
  occur at all: across 114 pending questions, several open for half an hour or
  more, not one conversation entry was written underneath. Handled anyway, by
  carrying the calls outstanding on the current turn in the same streaming pass.

- **Bounded to the turn in progress, deliberately.** Not a whole-file scan for a
  `tool_use` without a `tool_result`: a call left open by a crash would otherwise
  block every fork for the life of the session. Resetting at each assistant
  `text` block forgets the anomaly as soon as one more answer lands.

The first two cuts of this rule were both wrong in ways only measurement caught
— a `system`-only sidecar skip, and treating every user tail as an unfinished
turn, which refused a fork after `!git status` or after a background agent
reported in. Corpus verdicts now: 174 of 180 transcripts fork immediately, 6
wait first, none refuse on the spot.

# Verification

20-row decision matrix on fixtures lifted from real on-disk entries; live runs
of all five paths against a stub `herdr` (wait→fork at 3s, timeout with no
`exec claude`, transcript deleted mid-poll, both refusal texts replayed through
a real interactive zsh); `bash -n` under the system bash 3.2.57, which is the
real target. jq streams in constant memory — 8.2MB resident on the largest
7.8MB transcript, against 19MB to slurp it — so 30 polls cost about 1.5s of CPU.

Reviewed by a second agent, twice, which is where both design errors above came
from.

# Not in scope

`fork.sh` still does not carry the source pane's `--add-dir` set or
`CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD` over to the fork, the way
`fresh.sh` does. A fork of a `cw` pane therefore sees a different set of repos
than the pane it came from. Separate defect, untouched here.
