### PR TITLE
Preview markdown in the desktop browser, and stop previews sharing one file

### DIFF
--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -301,15 +301,31 @@ ensure_server() {
 # `.recent // .file` also covers an older server on this port, which ensure_server
 # below goes out of its way to contemplate: no `recent` field means fall back to
 # the one field it does have.
+#
+# Both fields are read either way, so that a failure can say which kind of
+# nothing it found. jq turns a silent curl - or a foreign server answering
+# something that is not JSON - into empty output rather than a failure.
 resume_current_file() {
+  health=$(curl -fsS -m 2 "${base}/health" 2>/dev/null) || health=''
+  recent=$(printf '%s' "$health" | jq -r '.recent // .file // empty' 2>/dev/null) \
+    || recent=''
   if [ "$1" = recent ]; then
-    field='.recent // .file // empty'
+    file=$recent
   else
-    field='.file // empty'
+    file=$(printf '%s' "$health" | jq -r '.file // empty' 2>/dev/null) || file=''
   fi
-  file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r "$field")
   if [ -z "$file" ]; then
-    echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
+    # A pane mode finding no pane-side file while a browser tab is holding one is
+    # not "nothing is being previewed" - something is, and saying otherwise is
+    # false in exactly the state it prints in. --browser never moves the current
+    # file, on purpose, so this is the ordinary consequence of previewing in a tab
+    # and then asking to rebuild a pane. What --reset needs is a file to rebuild
+    # onto, so it asks for one rather than adopting the tab's.
+    if [ "$1" != recent ] && [ -n "$recent" ]; then
+      printf '%s\n' "mdpreview: nothing is being previewed in a pane - ${recent} is open in a browser tab, which --reset does not rebuild; name a file: 'mdpreview --reset <file.md>'" >&2
+    else
+      echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
+    fi
     exit 1
   fi
   if [ ! -f "$file" ]; then

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -19,8 +19,10 @@
 # run from a plain terminal falls back to now that it has no tab for a pane.
 #
 # Which pane and view in this tab hold the preview is decided here, in every
-# mode. Nothing outside needs to read `herdr pane list` or `herdr-browser views`
-# to use a preview, and nothing outside should have to.
+# mode that has one to decide. Nothing outside needs to read `herdr pane list`
+# or `herdr-browser views` to use a preview, and nothing outside should have to.
+# The browser-tab modes have neither to answer for, which is exactly what lets
+# them run from a plain terminal where those lists have nothing to say.
 set -e
 
 port=${MDPREVIEW_PORT:-43128}
@@ -269,13 +271,81 @@ ensure_server() {
   fi
 }
 
+# Sets `file` to whatever the render server is currently showing, for the modes
+# that take no file argument, and leaves our own server up and ready to show it
+# again. Everything a named file needs, in other words, for the case where the
+# file is not named but is already on screen.
+#
+# A server has to be up already: a fresh one has no current file, and starting
+# one here would restore onto a blank page. jq turns a silent curl into empty
+# output rather than a failure.
+#
+# The file is read before ownership of the port is settled, and deliberately so.
+# The server answering may be one this copy does not own - left from before the
+# rename, or another checkout - and its current file is still the file on screen,
+# which is the thing being restored. Retiring it first would throw away the only
+# record of what to restore onto. ensure_server then makes our server the one
+# that gets the file back and the one the pane or tab is pointed at, so nothing
+# afterwards renders through code this copy does not have.
+#
+# require_deps waits until there is something to restore, for the same reason:
+# complaining about node_modules is the right answer when a preview is wanted
+# and the wrong one when the answer is that there is no preview to return to.
+resume_current_file() {
+  file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r '.file // empty')
+  if [ -z "$file" ]; then
+    echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
+    exit 1
+  fi
+  if [ ! -f "$file" ]; then
+    echo "mdpreview: the previewed file is gone: $file" >&2
+    exit 1
+  fi
+  require_deps
+  ensure_server
+}
+
 # Handing the file over reloads a preview that is already up, so the call waits
 # until every check that could still fail has passed: an error that leaves the
 # pane showing the new file would be reporting a failure it did not have.
+#
+# curl runs without -f on purpose. The server refuses a path it will not render
+# - a suffix outside the markdown set it recognises, a file it cannot read - and
+# answers 400 with the reason in the body's `error` field. -f throws that body
+# away, so all that reaches the caller is `curl: (22) The requested URL returned
+# error: 400`, naming neither the file nor what was wrong with it, and set -e
+# ends the run on curl's status before anything can say more. --fail-with-body
+# would keep the status and the body together in one flag, and is not used
+# because it arrived in curl 7.76 while this runs on whatever curl the machine
+# came with. So success is read out of the reply, and curl's own status is left
+# to mean the narrower thing it can still be trusted for: the request did not
+# happen at all.
 set_file() {
-  jq -n --arg path "$file" '{path: $path}' \
-    | curl -fsS -X POST -H 'content-type: application/json' --data @- "${base}/open" \
-    >/dev/null
+  if ! reply=$(jq -n --arg path "$file" '{path: $path}' \
+      | curl -sS -X POST -H 'content-type: application/json' --data @- "${base}/open"); then
+    echo "mdpreview: could not hand ${file} to the render server on ${base}" >&2
+    exit 1
+  fi
+  # A reply that is not the object expected here has to read as a refusal and
+  # not as consent. jq indexing a string is an error rather than a false, and
+  # taking that quietly would report a preview the server never accepted - so
+  # the shape is checked before the field is, and both reads are asked for
+  # separately: `.error` is absent from the success shape and would answer the
+  # same empty for a refusal that failed to say why.
+  ok=$(printf '%s' "$reply" \
+    | jq -r 'if type == "object" then (.ok // false) else false end' 2>/dev/null) \
+    || ok=false
+  if [ "$ok" = true ]; then
+    return 0
+  fi
+  reason=$(printf '%s' "$reply" \
+    | jq -r 'if type == "object" then (.error // empty) else empty end' 2>/dev/null) \
+    || reason=''
+  if [ -z "$reason" ]; then
+    reason="it refused and said nothing about why"
+  fi
+  echo "mdpreview: the render server on ${port} would not take ${file} - ${reason}" >&2
+  exit 1
 }
 
 # --target-pane keeps the split in this tab; without it the pane lands next to
@@ -292,37 +362,75 @@ open_pane() {
     --env "HERDR_BROWSER_INITIAL_URL=${base}/" --no-focus
 }
 
-# Hands a URL to whatever the desktop treats as a browser: `open` on macOS,
-# `xdg-open` on Linux. Both return as soon as the browser has been told, so
-# there is no tab to wait for here and nothing to report back beyond having
-# asked - and no view id either, which is the difference that matters: a tab
-# opened this way is not a herdr-browser view and cannot be driven over CDP.
+# The command that hands a URL to the desktop browser, or nothing when the
+# machine has neither. Chosen by platform rather than by which name turns up on
+# PATH first: on Darwin `open` opens a URL, but on Linux a program called `open`
+# is as likely to be something else - util-linux ships `openvt` and some
+# distributions link `open` to it, and a personal shim under that name is a
+# common enough habit - and preferring it there would spend the run on something
+# that was never going to show a page while `xdg-open` sat untried next to it.
+# Each platform's second choice is kept rather than dropped: a Darwin box
+# without `open` is odd but not a reason to refuse, and neither is a Linux one
+# where only the macOS name has been shimmed in.
 #
-# Neither one present is fatal rather than a warning, because a silent failure
-# here looks exactly like a browser that opened on another desktop. The message
-# names the URL so that a machine with no opener at all is still one command
-# away from the preview by hand.
-open_url() {
-  if command -v open >/dev/null 2>&1; then
-    open "$1"
-  elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$1"
+# Resolved separately from being run so that the one failure knowable in advance
+# - no opener installed at all - can be reported before the file has been handed
+# to the server, which is the step that navigates any pane already on this
+# preview. The other failure, an opener that exists and then exits non-zero,
+# cannot be known without running it and so necessarily lands after that; set -e
+# ends the run on it, with whatever the opener itself had to say.
+find_opener() {
+  if [ "$(uname -s)" = Darwin ]; then
+    first=open
+    second=xdg-open
   else
-    echo "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at $1" >&2
-    exit 1
+    first=xdg-open
+    second=open
   fi
+  if command -v "$first" >/dev/null 2>&1; then
+    printf '%s\n' "$first"
+  elif command -v "$second" >/dev/null 2>&1; then
+    printf '%s\n' "$second"
+  fi
+}
+
+# Hands the URL over, with the opener already settled by find_opener. Both
+# openers return as soon as the browser has been told, so there is no tab to
+# wait for here and nothing to report back beyond having asked - and no view id
+# either, which is the difference that matters downstream: a tab opened this way
+# is not a herdr-browser view and cannot be driven over CDP.
+#
+# Focus is taken, and that is the choice rather than an oversight. open_pane
+# passes --no-focus because a pane is already on screen in a tab being looked
+# at, so taking the keyboard for it would interrupt whoever asked - but asking
+# for a browser tab is asking to be shown one, and a tab that opens behind the
+# terminal is a preview that did not happen. The unscoped fallback inherits the
+# same behaviour without having asked for it; that is the cost of a path whose
+# only remaining place to put a preview is a browser.
+open_url() {
+  "$1" "$2"
 }
 
 # The whole of a browser preview once the file and the server are settled.
 #
-# The file goes to the server before the tab is opened, and not the other way
-# round: a tab that loads first renders whatever the server still held, and the
-# reload that POSTing the file broadcasts only reaches a page already listening
-# on /events - which a tab still starting up is not. Opening second costs
-# nothing, because the page is rendered per request.
+# The opener is looked up first, before set_file, so that a machine with no
+# opener is turned away while nothing has changed yet: set_file navigates every
+# page on this preview, a herdr pane included, so failing after it would move
+# someone's pane and then report that nothing had been shown.
+#
+# The file still goes to the server before the tab is opened, and not the other
+# way round: a tab that loads first renders whatever the server was holding, and
+# the reload that POSTing the file broadcasts only reaches a page already
+# listening on /events - which a tab still starting up is not. Opening second
+# costs nothing, because the page is rendered per request.
 preview_in_browser() {
+  opener=$(find_opener)
+  if [ -z "$opener" ]; then
+    echo "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at ${base}/" >&2
+    exit 1
+  fi
   set_file
-  open_url "${base}/"
+  open_url "$opener" "${base}/"
   echo "mdpreview: previewing ${file} in a browser tab"
 }
 
@@ -382,7 +490,17 @@ if [ "$1" = "--view" ]; then
   # open anywhere.
   resolve_target
   if [ "$target" = open ]; then
-    echo "mdpreview: no herdr-browser pane in this tab - run 'mdpreview <file.md>' first" >&2
+    # Two unrelated failures land here and they want different advice. Scoped,
+    # the tab simply has no preview yet and running one is the fix. Unscoped
+    # there is no tab for a message to be about, and previewing a file cannot be
+    # the fix any more: that opens a browser tab, which has no view id and never
+    # acquires one, so the old advice would send the caller round the same
+    # failure for as long as they were willing to follow it.
+    if [ "$scoped" = 1 ]; then
+      echo "mdpreview: no herdr-browser pane in this tab - run 'mdpreview <file.md>' first" >&2
+    else
+      echo "mdpreview: --view needs a herdr pane - outside a herdr session the preview is a browser tab, which has no view id to name" >&2
+    fi
     exit 1
   fi
   printf '%s\n' "$target"
@@ -432,28 +550,8 @@ if [ "$1" = "--reset" ]; then
     resolve_file "$2"
     ensure_server
   else
-    # Reuses whatever is on screen, which means a server has to be up already:
-    # a fresh one has no current file, and starting one here would reset onto a
-    # blank page. jq turns a silent curl into empty output rather than a failure.
-    #
-    # The file is read before ownership of the port is settled, and deliberately
-    # so. The server answering may be one this copy does not own - left from
-    # before the rename, or another checkout - and its current file is still the
-    # file on screen, which is the thing being restored. Retiring it first would
-    # throw away the only record of what to reset onto. ensure_server then makes
-    # our server the one that gets the file back and the one the pane is pointed
-    # at, so nothing here renders through code this copy does not have.
-    file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r '.file // empty')
-    if [ -z "$file" ]; then
-      echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
-      exit 1
-    fi
-    if [ ! -f "$file" ]; then
-      echo "mdpreview: the previewed file is gone: $file" >&2
-      exit 1
-    fi
-    require_deps
-    ensure_server
+    # No file named: reset onto whatever is on screen now.
+    resume_current_file
   fi
 
   for stage in pane daemon; do
@@ -500,25 +598,11 @@ if [ "$1" = "--browser" ]; then
     resolve_file "$2"
     ensure_server
   else
-    # No file named: show whatever the server already holds, the way --reset
-    # with no argument does, and read before ensure_server for the same reason.
-    # The server answering may be one this copy does not own - left from before
-    # a rename, or another checkout - and its current file is still the file on
-    # screen; retiring it first would throw away the only record of what to
-    # reopen. ensure_server then makes our server the one that gets the file
-    # back and the one the tab is pointed at. jq turns a silent curl into empty
-    # output rather than a failure.
-    file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r '.file // empty')
-    if [ -z "$file" ]; then
-      echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
-      exit 1
-    fi
-    if [ ! -f "$file" ]; then
-      echo "mdpreview: the previewed file is gone: $file" >&2
-      exit 1
-    fi
-    require_deps
-    ensure_server
+    # No file named: open a tab on whatever is on screen now. Handing the file
+    # back over broadcasts a reload, so a preview already open on a long
+    # document loses its scroll position - the cost of this taking the same
+    # route as a named file rather than trusting a server it may not own.
+    resume_current_file
   fi
 
   preview_in_browser
@@ -545,20 +629,32 @@ case $1 in
     # answered. herdr-browser rejects a word that is not one of its commands,
     # which is why this needs no list of them to keep in step with.
     #
-    # All of them drive a page over CDP, and the only page reachable that way is
-    # one the browser plugin owns. A tab handed to the desktop browser is not:
-    # nothing is attached to it and no view id names it, so unscoped there is
-    # nothing here to drive. Saying so is the whole answer - falling through to
+    # Whatever the word turns out to be, it is going to a view to be run
+    # against, over CDP, and the only page reachable that way is one the browser
+    # plugin owns. A tab handed to the desktop browser is not: nothing is
+    # attached to it and no view id names it, so unscoped there is nothing here
+    # to drive at all. Saying so is the whole answer - falling through to
     # any_view would report on a Chrome in another tab, and `text` returning a
     # document nobody here is looking at is worse than no answer, because it
     # reads as the preview and is not.
+    #
+    # The message stops short of calling the word a command, because the case
+    # above sends everything it does not recognise as a path down here and a
+    # mistyped filename is at least as likely as a real one. Naming the spelling
+    # rule is what turns the refusal into something the caller can act on.
     if [ "$scoped" != 1 ]; then
-      echo "mdpreview: '$1' drives a herdr-browser pane over CDP, and outside a herdr session the preview is a plain browser tab - run it from a herdr pane" >&2
+      echo "mdpreview: '$1' would be run against a herdr-browser view, and outside a herdr session there is none - the preview is a plain browser tab." >&2
+      echo "mdpreview: run it from a herdr pane; if '$1' was meant as a file to preview, name it with a .md suffix or a ./ prefix." >&2
       exit 1
     fi
     resolve_target
     if [ "$target" = open ]; then
-      echo "mdpreview: no preview in this tab - run 'mdpreview <file.md>' first" >&2
+      # --browser is named here because it opens a preview this cannot reach: a
+      # desktop tab has no view, so a tab opened moments ago still leaves this
+      # with nothing to drive and reads as no preview at all. Advising a bare
+      # `mdpreview <file.md>` on its own would then be advising a second preview
+      # surface rather than a fix.
+      echo "mdpreview: no herdr-browser pane in this tab - run 'mdpreview <file.md>' to open one; a preview opened with --browser is a desktop tab and cannot be driven from here" >&2
       exit 1
     fi
     export HERDR_BROWSER_VIEW_ID=$target

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -1,6 +1,8 @@
 #!/bin/sh
-# Preview a markdown file (mermaid included) in a herdr-browser pane.
+# Preview a markdown file (mermaid included) in a herdr-browser pane, or in the
+# desktop browser.
 #   mdpreview README.md
+#   mdpreview --browser [file.md]  # a desktop browser tab instead of a pane
 #   mdpreview text                 # any herdr-browser command, aimed at this
 #   mdpreview console              # tab's preview - no view id to pass around
 #   mdpreview screenshot --output /tmp/preview.png
@@ -11,7 +13,10 @@
 #   mdpreview --stop
 #
 # Starts a local render server on first use and reuses it afterwards; the page
-# live-reloads when the file changes.
+# live-reloads when the file changes. Nothing in that server knows about herdr -
+# it serves plain HTTP on the loopback port below - so the same preview shows in
+# an ordinary browser tab. That is what --browser asks for outright, and what a
+# run from a plain terminal falls back to now that it has no tab for a pane.
 #
 # Which pane and view in this tab hold the preview is decided here, in every
 # mode. Nothing outside needs to read `herdr pane list` or `herdr-browser views`
@@ -191,8 +196,13 @@ resolve_target() {
       exit 1
     fi
   else
-    # Outside herdr there is no tab to scope to and no pane to split from, so any
-    # view counts and a new pane lands next to whatever pane has focus.
+    # Only --view arrives here now. Outside herdr there is no tab to scope to and
+    # no pane to split from, so a view found this way is a Chrome in some other
+    # tab and a pane opened this way lands next to whatever pane has focus -
+    # neither of them anywhere the caller can look, which is why previewing and
+    # driving a preview both stop short of this branch and go to the browser or
+    # refuse outright. --view keeps it because a caller asking for a view id by
+    # name has asked for whatever the daemon has, not for a preview.
     target=$(any_view) || die_views
     if [ -z "$target" ]; then
       target=open
@@ -280,6 +290,40 @@ open_pane() {
     --placement split --direction right \
     ${HERDR_PANE_ID:+--target-pane "$HERDR_PANE_ID"} \
     --env "HERDR_BROWSER_INITIAL_URL=${base}/" --no-focus
+}
+
+# Hands a URL to whatever the desktop treats as a browser: `open` on macOS,
+# `xdg-open` on Linux. Both return as soon as the browser has been told, so
+# there is no tab to wait for here and nothing to report back beyond having
+# asked - and no view id either, which is the difference that matters: a tab
+# opened this way is not a herdr-browser view and cannot be driven over CDP.
+#
+# Neither one present is fatal rather than a warning, because a silent failure
+# here looks exactly like a browser that opened on another desktop. The message
+# names the URL so that a machine with no opener at all is still one command
+# away from the preview by hand.
+open_url() {
+  if command -v open >/dev/null 2>&1; then
+    open "$1"
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$1"
+  else
+    echo "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at $1" >&2
+    exit 1
+  fi
+}
+
+# The whole of a browser preview once the file and the server are settled.
+#
+# The file goes to the server before the tab is opened, and not the other way
+# round: a tab that loads first renders whatever the server still held, and the
+# reload that POSTing the file broadcasts only reaches a page already listening
+# on /events - which a tab still starting up is not. Opening second costs
+# nothing, because the page is rendered per request.
+preview_in_browser() {
+  set_file
+  open_url "${base}/"
+  echo "mdpreview: previewing ${file} in a browser tab"
 }
 
 # Chrome sometimes stops acknowledging pointer input while the rest of CDP stays
@@ -446,8 +490,43 @@ if [ "$1" = "--reset" ]; then
   exit 1
 fi
 
+if [ "$1" = "--browser" ]; then
+  # Shows the preview in the desktop browser instead of in a pane. No pane, no
+  # view and no daemon are involved, which is why this is deliberately not
+  # guarded by require_tab: asked for from inside a herdr session it means "not
+  # in a pane this time", and that is a thing to honour rather than to refuse.
+  if [ -n "$2" ]; then
+    require_deps
+    resolve_file "$2"
+    ensure_server
+  else
+    # No file named: show whatever the server already holds, the way --reset
+    # with no argument does, and read before ensure_server for the same reason.
+    # The server answering may be one this copy does not own - left from before
+    # a rename, or another checkout - and its current file is still the file on
+    # screen; retiring it first would throw away the only record of what to
+    # reopen. ensure_server then makes our server the one that gets the file
+    # back and the one the tab is pointed at. jq turns a silent curl into empty
+    # output rather than a failure.
+    file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r '.file // empty')
+    if [ -z "$file" ]; then
+      echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
+      exit 1
+    fi
+    if [ ! -f "$file" ]; then
+      echo "mdpreview: the previewed file is gone: $file" >&2
+      exit 1
+    fi
+    require_deps
+    ensure_server
+  fi
+
+  preview_in_browser
+  exit 0
+fi
+
 if [ -z "$1" ]; then
-  echo "usage: mdpreview <file.md> | <herdr-browser command> | --view | --pane | --screen | --reset [file.md] | --stop" >&2
+  echo "usage: mdpreview <file.md> | <herdr-browser command> | --browser [file.md] | --view | --pane | --screen | --reset [file.md] | --stop" >&2
   exit 1
 fi
 
@@ -465,6 +544,18 @@ case $1 in
     # read the pane and view lists to answer a question this script has already
     # answered. herdr-browser rejects a word that is not one of its commands,
     # which is why this needs no list of them to keep in step with.
+    #
+    # All of them drive a page over CDP, and the only page reachable that way is
+    # one the browser plugin owns. A tab handed to the desktop browser is not:
+    # nothing is attached to it and no view id names it, so unscoped there is
+    # nothing here to drive. Saying so is the whole answer - falling through to
+    # any_view would report on a Chrome in another tab, and `text` returning a
+    # document nobody here is looking at is worse than no answer, because it
+    # reads as the preview and is not.
+    if [ "$scoped" != 1 ]; then
+      echo "mdpreview: '$1' drives a herdr-browser pane over CDP, and outside a herdr session the preview is a plain browser tab - run it from a herdr pane" >&2
+      exit 1
+    fi
     resolve_target
     if [ "$target" = open ]; then
       echo "mdpreview: no preview in this tab - run 'mdpreview <file.md>' first" >&2
@@ -478,6 +569,18 @@ esac
 require_deps
 resolve_file "$1"
 ensure_server
+
+# Unscoped, the preview goes to the desktop browser rather than into herdr. This
+# used to reach for any view at all and split a pane if it found none, and both
+# halves of that put the preview where whoever ran the command cannot see it -
+# in another tab's Chrome, or beside whichever pane happens to have focus. From
+# a plain terminal it never even got that far: with no herdr-browser daemon up,
+# reading the view list fails and the run dies at die_views. A browser tab is
+# somewhere they are looking, and it needs none of that machinery.
+if [ "$scoped" != 1 ]; then
+  preview_in_browser
+  exit 0
+fi
 
 resolve_target
 

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -291,8 +291,23 @@ ensure_server() {
 # require_deps waits until there is something to restore, for the same reason:
 # complaining about node_modules is the right answer when a preview is wanted
 # and the wrong one when the answer is that there is no preview to return to.
+# $1 picks which of the two files /health reports to come back to. `current` is
+# the file a bare / renders, which is the one the pane modes last opened and so
+# the one --reset means by "whatever is on screen". `recent` is the most recent
+# /open of any kind, which is what --browser means: a browser preview registers
+# its file without making it current, precisely so that it cannot drag a pane
+# along, and would otherwise have nothing to resume from at all.
+#
+# `.recent // .file` also covers an older server on this port, which ensure_server
+# below goes out of its way to contemplate: no `recent` field means fall back to
+# the one field it does have.
 resume_current_file() {
-  file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r '.file // empty')
+  if [ "$1" = recent ]; then
+    field='.recent // .file // empty'
+  else
+    field='.file // empty'
+  fi
+  file=$(curl -fsS -m 2 "${base}/health" 2>/dev/null | jq -r "$field")
   if [ -z "$file" ]; then
     echo "mdpreview: nothing is being previewed - run 'mdpreview <file.md>'" >&2
     exit 1
@@ -305,9 +320,16 @@ resume_current_file() {
   ensure_server
 }
 
-# Handing the file over reloads a preview that is already up, so the call waits
-# until every check that could still fail has passed: an error that leaves the
-# pane showing the new file would be reporting a failure it did not have.
+# Registers the file with the render server, which is also what reloads a page
+# already showing it - so the call waits until every check that could still fail
+# has passed: an error that leaves the pane showing the new file would be
+# reporting a failure it did not have.
+#
+# `set_file aside` registers without making the file the current one. Only the
+# browser path uses it, and the reason is on the server side, at registerFile: a
+# page reached through a bare / follows the current file and would be dragged
+# onto a file someone asked to see in a tab of its own. Panes are on their own
+# ?file= URL and never see it either way.
 #
 # curl runs without -f on purpose. The server refuses a path it will not render
 # - a suffix outside the markdown set it recognises, a file it cannot read - and
@@ -331,7 +353,12 @@ resume_current_file() {
 # accepts the connection and then never answers would hang the run forever with
 # nothing on screen to say why.
 set_file() {
-  if ! reply=$(jq -n --arg path "$file" '{path: $path}' \
+  current=true
+  if [ "${1:-}" = aside ]; then
+    current=false
+  fi
+  if ! reply=$(jq -n --arg path "$file" --argjson current "$current" \
+        '{path: $path, current: $current}' \
       | curl -sS -m 10 -X POST -H 'content-type: application/json' --data @- "${base}/open"); then
     printf '%s\n' "mdpreview: no reply from the render server on ${base} - ${file} may already have reached it" >&2
     exit 1
@@ -370,6 +397,39 @@ set_file() {
   exit 1
 }
 
+# The URL for one preview surface, with the file in the query rather than left to
+# whatever the server happens to think is current. That is what makes two
+# previews possible at once: a pane in this tab, a pane in another, and any
+# number of browser tabs each hold their own path, and a save reloads only the
+# pages showing that path.
+#
+# $1 is the surface, `pane` or `tab`. The server cannot tell them apart - both
+# are Chrome asking for a page - so the page carries the answer for the sake of
+# the duplicate-tab check, which must count tabs and not panes.
+#
+# @uri and not the path as typed: a path may hold spaces, and a `&` or a `#` in
+# one would otherwise end the query or the URL early, handing the server half a
+# path and an argument it never saw.
+preview_url() {
+  printf '%s/?file=%s&surface=%s\n' \
+    "$base" "$(jq -rn --arg p "$file" '$p|@uri')" "$1"
+}
+
+# How many browser tabs already have this file open, or 0 when the question
+# cannot be answered - an older server has no /viewers, and its silence has to
+# read as "no tabs" so that the preview still happens.
+#
+# Only tabs count. A herdr pane showing the same file is not a reason to refuse
+# someone who asked for a browser tab, and server.ts excludes it for that reason.
+tab_viewers() {
+  count=$(curl -fsS -m 2 "${base}/viewers?file=$(jq -rn --arg p "$file" '$p|@uri')" \
+    2>/dev/null | jq -r '.count // 0') || count=0
+  case $count in
+    '' | *[!0-9]*) count=0 ;;
+  esac
+  printf '%s\n' "$count"
+}
+
 # --target-pane keeps the split in this tab; without it the pane lands next to
 # whichever pane happens to be focused, which need not be this one.
 #
@@ -381,7 +441,7 @@ open_pane() {
     --plugin official.browser --entrypoint browser \
     --placement split --direction right \
     ${HERDR_PANE_ID:+--target-pane "$HERDR_PANE_ID"} \
-    --env "HERDR_BROWSER_INITIAL_URL=${base}/" --no-focus
+    --env "HERDR_BROWSER_INITIAL_URL=$(preview_url pane)" --no-focus
 }
 
 # The command that hands a URL to the desktop browser, or nothing when the
@@ -439,14 +499,34 @@ find_opener() {
 # terminal is a preview that did not happen. The unscoped fallback inherits the
 # same behaviour without having asked for it; that is the cost of a path whose
 # only remaining place to put a preview is a browser.
+# A tab already showing this file is left alone rather than joined by a second
+# one. `open` starts a tab; it does not look for an existing one, so without this
+# every run stacked another tab on the same preview - and the file has just been
+# re-registered, which reloads the tab that is already there, so the preview is
+# as fresh as a new tab would have been.
+#
+# The count comes from live SSE connections, so a tab Chrome has discarded or
+# frozen in the background reads as gone and a second one opens. Erring that way
+# is deliberate: the alternative is refusing to show a preview because of a tab
+# the user can no longer see.
 preview_in_browser() {
   opener=$(find_opener)
   if [ -z "$opener" ]; then
-    printf '%s\n' "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at ${base}/" >&2
+    printf '%s\n' "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at $(preview_url tab)" >&2
     exit 1
   fi
-  set_file
-  "$opener" "${base}/"
+  # Asked before the file is handed over, and that ordering is not cosmetic:
+  # registering it reloads every page already showing it, and a page in the
+  # middle of a reload has dropped its EventSource and not yet reopened it. A
+  # count taken afterwards races the very tab it is looking for and comes back 0,
+  # which stacks a second tab on every run - the exact bug this is here to stop.
+  showing=$(tab_viewers)
+  set_file aside
+  if [ "$showing" -gt 0 ]; then
+    printf '%s\n' "mdpreview: ${file} is already open in a browser tab - reloaded that instead of opening another"
+    return 0
+  fi
+  "$opener" "$(preview_url tab)"
   printf '%s\n' "mdpreview: previewing ${file} in a browser tab"
 }
 
@@ -572,8 +652,11 @@ if [ "$1" = "--reset" ]; then
     resolve_file "$2"
     ensure_server
   else
-    # No file named: reset onto whatever is on screen now.
-    resume_current_file
+    # No file named: reset onto whatever the pane modes last opened, which is
+    # what is on screen in a pane. A file someone opened in a browser tab with
+    # --browser is not that, and pulling this tab's pane onto it would be a
+    # reset onto something the pane was never showing.
+    resume_current_file current
   fi
 
   # Handed over before the loop, because close_panes below is destructive and
@@ -634,11 +717,12 @@ if [ "$1" = "--browser" ]; then
     resolve_file "$2"
     ensure_server
   else
-    # No file named: open a tab on whatever is on screen now. Handing the file
-    # back over broadcasts a reload, so a preview already open on a long
-    # document loses its scroll position - the cost of this taking the same
-    # route as a named file rather than trusting a server it may not own.
-    resume_current_file
+    # No file named: open a tab on the most recent file any surface was pointed
+    # at, which is what "the preview" means to someone who did not name one.
+    # Handing it back over broadcasts a reload, so a page already open on a long
+    # document loses its scroll position - the cost of this taking the same route
+    # as a named file rather than trusting a server it may not own.
+    resume_current_file recent
   fi
 
   preview_in_browser
@@ -741,5 +825,5 @@ set_file
 # still exiting 0. Closing the pane in the moment between the check above and
 # this line is enough to hit it, and it is silent when it happens.
 export HERDR_BROWSER_VIEW_ID=$target
-herdr-browser open "${base}/" >/dev/null
+herdr-browser open "$(preview_url pane)" >/dev/null
 printf '%s\n' "mdpreview: previewing ${file}"

--- a/.config/herdr/bin/mdpreview
+++ b/.config/herdr/bin/mdpreview
@@ -78,13 +78,13 @@ if [ "$1" = "--stop" ]; then
   # killing by directory alone is what this exists to avoid. Saying so beats
   # reporting a stop that did not happen.
   if ! command -v lsof >/dev/null 2>&1; then
-    echo "mdpreview: lsof is needed to find the server on ${port}" >&2
+    printf '%s\n' "mdpreview: lsof is needed to find the server on ${port}" >&2
     exit 1
   fi
   if stop_server; then
-    echo "mdpreview: stopped the server on ${port}"
+    printf '%s\n' "mdpreview: stopped the server on ${port}"
   else
-    echo "mdpreview: no server on ${port}"
+    printf '%s\n' "mdpreview: no server on ${port}"
   fi
   exit 0
 fi
@@ -114,7 +114,7 @@ die_views() {
 
 require_tab() {
   if [ "$scoped" != 1 ]; then
-    echo "mdpreview: $1 needs a herdr pane to scope to - there is no tab to look in from a plain terminal" >&2
+    printf '%s\n' "mdpreview: $1 needs a herdr pane to scope to - there is no tab to look in from a plain terminal" >&2
     exit 1
   fi
 }
@@ -214,7 +214,7 @@ resolve_target() {
 
 require_deps() {
   if [ ! -d "${root}/node_modules" ]; then
-    echo "mdpreview: dependencies missing - run 'bun install' in ${root}" >&2
+    printf '%s\n' "mdpreview: dependencies missing - run 'bun install' in ${root}" >&2
     exit 1
   fi
 }
@@ -226,7 +226,7 @@ require_deps() {
 resolve_file() {
   dir=$(CDPATH= cd -- "$(dirname -- "$1")" 2>/dev/null && pwd) || dir=""
   if [ -z "$dir" ] || [ ! -f "${dir}/$(basename -- "$1")" ]; then
-    echo "mdpreview: no such file: $1" >&2
+    printf '%s\n' "mdpreview: no such file: $1" >&2
     exit 1
   fi
   file="${dir}/$(basename -- "$1")"
@@ -250,7 +250,7 @@ ensure_server() {
   # as nothing more than a page that will not change.
   if ! command -v lsof >/dev/null 2>&1 &&
       curl -fsS -m 1 "${base}/health" >/dev/null 2>&1; then
-    echo "mdpreview: no lsof, so the server already on ${port} cannot be identified - if the preview renders stale, stop that process by hand" >&2
+    printf '%s\n' "mdpreview: no lsof, so the server already on ${port} cannot be identified - if the preview renders stale, stop that process by hand" >&2
   fi
   for pid in $(server_pids); do
     if ! server_is_ours "$pid"; then
@@ -265,7 +265,7 @@ ensure_server() {
     # retry output is dropped and the final failure is reported here instead.
     if ! curl -fsS --retry 30 --retry-delay 0 --retry-connrefused -m 10 \
         "${base}/health" >/dev/null 2>/dev/null; then
-      echo "mdpreview: server did not start on ${base} - see ${TMPDIR:-/tmp}/mdpreview-server.log" >&2
+      printf '%s\n' "mdpreview: server did not start on ${base} - see ${TMPDIR:-/tmp}/mdpreview-server.log" >&2
       exit 1
     fi
   fi
@@ -298,7 +298,7 @@ resume_current_file() {
     exit 1
   fi
   if [ ! -f "$file" ]; then
-    echo "mdpreview: the previewed file is gone: $file" >&2
+    printf '%s\n' "mdpreview: the previewed file is gone: $file" >&2
     exit 1
   fi
   require_deps
@@ -317,23 +317,35 @@ resume_current_file() {
 # ends the run on curl's status before anything can say more. --fail-with-body
 # would keep the status and the body together in one flag, and is not used
 # because it arrived in curl 7.76 while this runs on whatever curl the machine
-# came with. So success is read out of the reply, and curl's own status is left
-# to mean the narrower thing it can still be trusted for: the request did not
-# happen at all.
+# came with. So success is read out of the reply instead, and curl's own status
+# is left to mean the one thing it still reports usefully: no reply arrived.
+#
+# Which is not the same as nothing having happened, and the message is careful
+# not to say otherwise. server.ts sets the current file and broadcasts the
+# reload before it writes the response, and curl exits non-zero for a partial
+# transfer or an empty reply as readily as for a connection it never made - so a
+# server killed mid-answer leaves every page on this preview already navigated
+# with no way for this to know.
+#
+# -m because this was the only curl in the file without one, and a server that
+# accepts the connection and then never answers would hang the run forever with
+# nothing on screen to say why.
 set_file() {
   if ! reply=$(jq -n --arg path "$file" '{path: $path}' \
-      | curl -sS -X POST -H 'content-type: application/json' --data @- "${base}/open"); then
-    echo "mdpreview: could not hand ${file} to the render server on ${base}" >&2
+      | curl -sS -m 10 -X POST -H 'content-type: application/json' --data @- "${base}/open"); then
+    printf '%s\n' "mdpreview: no reply from the render server on ${base} - ${file} may already have reached it" >&2
     exit 1
   fi
   # A reply that is not the object expected here has to read as a refusal and
   # not as consent. jq indexing a string is an error rather than a false, and
-  # taking that quietly would report a preview the server never accepted - so
-  # the shape is checked before the field is, and both reads are asked for
-  # separately: `.error` is absent from the success shape and would answer the
-  # same empty for a refusal that failed to say why.
+  # taking that quietly would report a preview the server never accepted.
+  #
+  # `.ok == true` rather than `.ok // false`, which under -r prints the string
+  # "true" for a `{"ok":"true"}` and passes the test below. Ours never sends
+  # that; a foreign server on this port is exactly the case none of this can
+  # assume anything about.
   ok=$(printf '%s' "$reply" \
-    | jq -r 'if type == "object" then (.ok // false) else false end' 2>/dev/null) \
+    | jq -r 'if type == "object" then (.ok == true) else false end' 2>/dev/null) \
     || ok=false
   if [ "$ok" = true ]; then
     return 0
@@ -342,9 +354,19 @@ set_file() {
     | jq -r 'if type == "object" then (.error // empty) else empty end' 2>/dev/null) \
     || reason=''
   if [ -z "$reason" ]; then
+    # jq finding no reason in a body it could not parse means it could not read
+    # one, not that there was none to read - and dropping -f above was the whole
+    # point of not discarding bodies. server.ts answers a bad Host or an
+    # unexpected Origin with a bare `forbidden`, and a foreign server on this
+    # port owes us no JSON at all, so the body itself is the reason in that
+    # case. One line and cut short, because this prints on one line of a
+    # terminal and an unknown server may well answer with an HTML page.
+    reason=$(printf '%s' "$reply" | head -n 1 | cut -c1-200)
+  fi
+  if [ -z "$reason" ]; then
     reason="it refused and said nothing about why"
   fi
-  echo "mdpreview: the render server on ${port} would not take ${file} - ${reason}" >&2
+  printf '%s\n' "mdpreview: the render server on ${port} would not take ${file} - ${reason}" >&2
   exit 1
 }
 
@@ -373,12 +395,8 @@ open_pane() {
 # without `open` is odd but not a reason to refuse, and neither is a Linux one
 # where only the macOS name has been shimmed in.
 #
-# Resolved separately from being run so that the one failure knowable in advance
-# - no opener installed at all - can be reported before the file has been handed
-# to the server, which is the step that navigates any pane already on this
-# preview. The other failure, an opener that exists and then exits non-zero,
-# cannot be known without running it and so necessarily lands after that; set -e
-# ends the run on it, with whatever the opener itself had to say.
+# Prints the name rather than running it, so that the caller decides when - see
+# preview_in_browser, where the when is the point.
 find_opener() {
   if [ "$(uname -s)" = Darwin ]; then
     first=open
@@ -394,11 +412,25 @@ find_opener() {
   fi
 }
 
-# Hands the URL over, with the opener already settled by find_opener. Both
-# openers return as soon as the browser has been told, so there is no tab to
-# wait for here and nothing to report back beyond having asked - and no view id
-# either, which is the difference that matters downstream: a tab opened this way
-# is not a herdr-browser view and cannot be driven over CDP.
+# The whole of a browser preview once the file and the server are settled.
+#
+# The opener is resolved before set_file and run after it, and that order is the
+# point. set_file navigates every page on this preview, a herdr pane included,
+# so the one opener failure knowable in advance - none installed at all - has to
+# be reported while nothing has changed yet; otherwise the run moves someone's
+# pane and then reports that nothing was shown. The other failure, an opener
+# that exists and exits non-zero, cannot be known without running it and so
+# necessarily lands after; set -e ends the run on it, with whatever the opener
+# itself had to say.
+#
+# The file still goes to the server before the tab is opened, and not the other
+# way round: a tab that loads first renders whatever the server was holding, and
+# the reload that POSTing the file broadcasts only reaches a page already
+# listening on /events - which a tab still starting up is not. Opening second
+# costs nothing, because the page is rendered per request. The opener returns as
+# soon as the browser has been told, so there is nothing to wait for and nothing
+# to report back beyond having asked - and no view id, which is the difference
+# the passthrough and --view both have to account for.
 #
 # Focus is taken, and that is the choice rather than an oversight. open_pane
 # passes --no-focus because a pane is already on screen in a tab being looked
@@ -407,31 +439,15 @@ find_opener() {
 # terminal is a preview that did not happen. The unscoped fallback inherits the
 # same behaviour without having asked for it; that is the cost of a path whose
 # only remaining place to put a preview is a browser.
-open_url() {
-  "$1" "$2"
-}
-
-# The whole of a browser preview once the file and the server are settled.
-#
-# The opener is looked up first, before set_file, so that a machine with no
-# opener is turned away while nothing has changed yet: set_file navigates every
-# page on this preview, a herdr pane included, so failing after it would move
-# someone's pane and then report that nothing had been shown.
-#
-# The file still goes to the server before the tab is opened, and not the other
-# way round: a tab that loads first renders whatever the server was holding, and
-# the reload that POSTing the file broadcasts only reaches a page already
-# listening on /events - which a tab still starting up is not. Opening second
-# costs nothing, because the page is rendered per request.
 preview_in_browser() {
   opener=$(find_opener)
   if [ -z "$opener" ]; then
-    echo "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at ${base}/" >&2
+    printf '%s\n' "mdpreview: no way to open a browser - neither open nor xdg-open is on PATH; the preview is at ${base}/" >&2
     exit 1
   fi
   set_file
-  open_url "$opener" "${base}/"
-  echo "mdpreview: previewing ${file} in a browser tab"
+  "$opener" "${base}/"
+  printf '%s\n' "mdpreview: previewing ${file} in a browser tab"
 }
 
 # Chrome sometimes stops acknowledging pointer input while the rest of CDP stays
@@ -496,10 +512,16 @@ if [ "$1" = "--view" ]; then
     # the fix any more: that opens a browser tab, which has no view id and never
     # acquires one, so the old advice would send the caller round the same
     # failure for as long as they were willing to follow it.
+    #
+    # The unscoped message reports the state and stops there. It must not say
+    # --view needs a herdr pane, because unscoped it does not: resolve_target
+    # hands back any view the daemon happens to have and this prints it, which
+    # is the behaviour that branch defends on purpose. What is true here is only
+    # that the daemon has none.
     if [ "$scoped" = 1 ]; then
       echo "mdpreview: no herdr-browser pane in this tab - run 'mdpreview <file.md>' first" >&2
     else
-      echo "mdpreview: --view needs a herdr pane - outside a herdr session the preview is a browser tab, which has no view id to name" >&2
+      echo "mdpreview: no herdr-browser view anywhere to name - outside a herdr session a preview is a plain browser tab, which has no view id; open a herdr-browser pane if a view is what you need" >&2
     fi
     exit 1
   fi
@@ -554,6 +576,20 @@ if [ "$1" = "--reset" ]; then
     resume_current_file
   fi
 
+  # Handed over before the loop, because close_panes below is destructive and
+  # this is the last step that can still refuse. `--reset FILE` never passes
+  # through the spelling rule further down, so resolve_file admits any existing
+  # path and the server is the first thing to reject it - which, done from inside
+  # the loop, happened after the tab's working preview had already been closed
+  # for a replacement that was never going to open. Same ordering the browser
+  # path gets, for the same reason.
+  #
+  # The in-loop calls stay: each stage is meant to be a complete attempt at
+  # getting the file on screen rather than something that leans on state set
+  # before a daemon restart it does not control. The repeated POST costs one
+  # reload broadcast, to panes that are being replaced anyway.
+  set_file
+
   for stage in pane daemon; do
     close_panes
     budget=50
@@ -575,9 +611,9 @@ if [ "$1" = "--reset" ]; then
     view=$(wait_view "$budget") || die_views
     if [ -n "$view" ] && ! input_wedged "$view"; then
       if [ "$stage" = daemon ]; then
-        echo "mdpreview: reset ok - browser daemon restarted, previewing ${file}"
+        printf '%s\n' "mdpreview: reset ok - browser daemon restarted, previewing ${file}"
       else
-        echo "mdpreview: reset ok - new preview pane, previewing ${file}"
+        printf '%s\n' "mdpreview: reset ok - new preview pane, previewing ${file}"
       fi
       exit 0
     fi
@@ -642,9 +678,14 @@ case $1 in
     # above sends everything it does not recognise as a path down here and a
     # mistyped filename is at least as likely as a real one. Naming the spelling
     # rule is what turns the refusal into something the caller can act on.
+    #
+    # printf and not echo, here and everywhere a message interpolates something:
+    # /bin/sh on this platform and dash both expand backslash escapes in echo
+    # without being asked, so a filename with a \t in it would be reported as a
+    # different name than the one that was typed.
     if [ "$scoped" != 1 ]; then
-      echo "mdpreview: '$1' would be run against a herdr-browser view, and outside a herdr session there is none - the preview is a plain browser tab." >&2
-      echo "mdpreview: run it from a herdr pane; if '$1' was meant as a file to preview, name it with a .md suffix or a ./ prefix." >&2
+      printf '%s\n' "mdpreview: '$1' would be run against a herdr-browser view, and outside a herdr session there is none - the preview is a plain browser tab." >&2
+      printf '%s\n' "mdpreview: run it from a herdr pane; if '$1' was meant as a file to preview, name it with a .md suffix or a ./ prefix." >&2
       exit 1
     fi
     resolve_target
@@ -687,7 +728,7 @@ resolve_target
 if [ "$target" = open ]; then
   set_file
   open_pane >/dev/null
-  echo "mdpreview: previewing ${file} in a new pane"
+  printf '%s\n' "mdpreview: previewing ${file} in a new pane"
   exit 0
 fi
 
@@ -701,4 +742,4 @@ set_file
 # this line is enough to hit it, and it is silent when it happens.
 export HERDR_BROWSER_VIEW_ID=$target
 herdr-browser open "${base}/" >/dev/null
-echo "mdpreview: previewing ${file}"
+printf '%s\n' "mdpreview: previewing ${file}"

--- a/.config/herdr/mdpreview-server/server.ts
+++ b/.config/herdr/mdpreview-server/server.ts
@@ -142,8 +142,21 @@ function broadcastReload(key: string): void {
     try {
       client.enqueue(payload);
     } catch {
+      // Only a cancelled stream ever lands here. enqueue on the controller of a
+      // stream that has been cancelled throws "Controller is already closed";
+      // enqueue on one whose start() threw does not throw at all, so this is not
+      // a general reaper and must not be read as one. The guard around watch()
+      // in startWatching is what covers that other case.
       channel.clients.delete(client);
     }
+  }
+  // Dropping the last client here has to close the watch as well. Otherwise the
+  // channel outlives the only audience its watchers had and they go on firing
+  // into an empty map - which is the state unsubscribe exists to prevent, and it
+  // is the only other place that runs this path.
+  if (channel.clients.size === 0) {
+    stopWatching(channel);
+    channels.delete(key);
   }
 }
 
@@ -222,23 +235,65 @@ function startWatching(key: string): void {
     names.set(dir, known);
   }
   for (const [dir, known] of names) {
-    channel.watchers.push(
-      watch(dir, (_event, changed) => {
-        // Fingerprint the path as opened, not the resolved one: statSync follows
-        // the link, so one comparison covers both an edit to the real file and a
-        // link repointed at a different file.
-        const state = fileState(file);
-        if (!known.has(changed ?? "") && state === channel.watchedState) {
-          return;
-        }
-        channel.watchedState = state;
-        if (channel.reloadTimer) {
-          clearTimeout(channel.reloadTimer);
-        }
-        channel.reloadTimer = setTimeout(() => broadcastReload(key), 50);
-      }),
-    );
+    // watch() throws synchronously - ENOENT - when the directory is not there,
+    // which is what a preview whose directory has been removed or renamed under
+    // it looks like. Letting that escape is what must not happen, and the reason
+    // is entirely about where this is called from. startWatching runs inside the
+    // ReadableStream start() of /events, a start() that throws propagates out of
+    // the constructor without cancel() ever running, and subscribe has already
+    // recorded the client by then - so the client stays in the channel with no
+    // stream behind it. Nothing reaps it later either: enqueue on a controller
+    // whose start() threw does not throw, so broadcastReload's catch never sees
+    // it. The channel would then report a phantom tab to /viewers and suppress
+    // --browser on that path for as long as the server lived.
+    //
+    // Giving up on the directory instead leaves the channel with no watchers,
+    // which is an inert state that already exists: it is what the empty key
+    // produces whenever nothing has been opened yet. The page stays connected
+    // and silent until /open comes back for the path - see rearmWatching - and
+    // that is also what the version before per-path channels did, only louder.
+    // There, watchFile was called from setCurrentFile inside /open's own try, so
+    // a missing directory came back as a clean 400 and /events was never part of
+    // it. Silence is the closer match to that than a 500 on the reload stream.
+    try {
+      channel.watchers.push(
+        watch(dir, (_event, changed) => {
+          // Fingerprint the path as opened, not the resolved one: statSync follows
+          // the link, so one comparison covers both an edit to the real file and a
+          // link repointed at a different file.
+          const state = fileState(file);
+          if (!known.has(changed ?? "") && state === channel.watchedState) {
+            return;
+          }
+          channel.watchedState = state;
+          if (channel.reloadTimer) {
+            clearTimeout(channel.reloadTimer);
+          }
+          channel.reloadTimer = setTimeout(() => broadcastReload(key), 50);
+        }),
+      );
+    } catch {
+      // This directory cannot be watched. Another entry in `names` still might -
+      // a symlinked target whose own directory survived, say - so the loop goes
+      // on rather than giving up on the file.
+    }
   }
+}
+
+// Re-arms the watch on a path that has pages connected to it.
+//
+// This is the recovery route for a channel startWatching gave up on: a preview
+// whose directory went away is connected and silent, and comes back the moment
+// something registers the path again. /open is the right place to do it from
+// because bin/mdpreview re-registers the file on every preview, so the thing
+// anyone does when a preview looks dead - run mdpreview again - is already the
+// fix, with nothing new to know.
+function rearmWatching(key: string): void {
+  const channel = channels.get(key);
+  if (!channel || channel.clients.size === 0) {
+    return;
+  }
+  startWatching(key);
 }
 
 function subscribe(
@@ -471,9 +526,14 @@ function shell(
   events: string,
   toc = "",
 ): string {
-  // JSON.stringify makes the URL a JS string literal; < is escaped on top of
-  // that because JSON.stringify leaves it alone, and a path spelling a closing
-  // script tag would otherwise end the block early.
+  // JSON.stringify is what makes this a JS string literal, and on its own it is
+  // already enough: `events` comes out of URLSearchParams.toString(), which
+  // percent-encodes everything outside [A-Za-z0-9*-._], so a path spelling a
+  // closing script tag arrives as %3C%2Fscript%3E and a U+2028 as %E2%80%A8 - no
+  // <, quote, backslash or line separator survives to reach it. The extra escape
+  // below therefore guards a string that currently cannot contain a <. It is
+  // kept as depth, so that building this URL some other way later cannot quietly
+  // turn a path into markup.
   const eventsLiteral = JSON.stringify(events).replaceAll("<", "\\u003c");
   return `<!doctype html>
 <html lang="en">
@@ -581,6 +641,10 @@ const server = Bun.serve({
         // Absent means current, so a script from before this change still works.
         const makeCurrent = current !== false;
         const file = await registerFile(path, makeCurrent);
+        // Before the reload, not after: a channel whose watch was given up on -
+        // its directory had gone - is watching nothing until this runs, and a
+        // page told to reload first would come back to a still-dead stream.
+        rearmWatching(file);
         // The file's own channel first, then the follow-current one if this
         // moved it. A page in both at once would be an odd thing to arrange and
         // the worst it costs is a second reload of a page that just reloaded.
@@ -598,9 +662,17 @@ const server = Bun.serve({
     if (pathname === "/viewers") {
       // Not for pages to call. It answers a question about what the user has
       // open, and no page has a use for the answer - bin/mdpreview is what asks,
-      // before deciding whether to open a tab. A same-origin GET carries no
-      // Origin, so this turns away a cross-origin caller rather than our own
-      // page; the cross-origin one is the caller it is here to turn away.
+      // before deciding whether to open a tab.
+      //
+      // The check is weaker here than on /open, and worth being honest about.
+      // What makes it decisive there is that browsers attach Origin to every
+      // cross-origin POST. A cross-origin GET made no-cors does not carry one -
+      // an <img src>, an iframe, a stylesheet link - so all this turns away is
+      // the fetch and XHR shapes, which same-origin policy already stops from
+      // reading the reply. Nothing follows from that on this route: it has no
+      // side effect and its body is unreadable cross-origin. The check stays
+      // because the route is not meant for pages, not because it is what makes
+      // that so.
       if (request.headers.get("origin") !== null) {
         return new Response("forbidden", { status: 403 });
       }
@@ -615,8 +687,16 @@ const server = Bun.serve({
     if (pathname === "/events") {
       // Reachable from the page, unlike /open and /viewers: this is the one
       // endpoint the preview itself has to call, and an EventSource is how it
-      // calls it. The registry check is what keeps that from being a way to ask
-      // the server to watch an arbitrary path and report when it changes.
+      // calls it. So it allows an Origin, which means any page anywhere can
+      // subscribe with an <img src="/events?file=..."> if it already knows a
+      // registered path's absolute spelling.
+      //
+      // The registry check covers what that would otherwise be worth - having
+      // the server watch a path of the caller's choosing and report when it
+      // changed. It does not cover the counting: surfaceFor reads such a client
+      // as a tab, so the trick can cost one suppressed --browser tab on a path
+      // the caller already knew the name of. That is the whole of it, and it
+      // does not earn any machinery.
       const target = targetFor(url);
       if (!target.ok) {
         return new Response("not found", { status: 404 });

--- a/.config/herdr/mdpreview-server/server.ts
+++ b/.config/herdr/mdpreview-server/server.ts
@@ -50,6 +50,14 @@ const marked = new Marked(
   {
     gfm: true,
     breaks: false,
+    // Asked for outright, because renderPage depends on parse being synchronous
+    // and the dependency is not obvious from the call. See the comment there:
+    // the table of contents comes out of a module-level list that the next parse
+    // clears, so nothing may yield between the parse and the read, and `await`
+    // was that yield. Setting it here rather than passing it per call keeps the
+    // renderer and the plugins above from going through an options merge on
+    // every render.
+    async: false,
     renderer: {
       code({ text, lang }) {
         const language = (lang ?? "").trim().split(/\s+/)[0] ?? "";
@@ -513,8 +521,36 @@ async function renderPage(url: URL): Promise<Response> {
     const message = error instanceof Error ? error.message : String(error);
     return htmlResponse(nonce, basename(file), file, `<p>${escapeHtml(message)}</p>`, events);
   }
-  // gfmHeadingId's preprocess hook clears the heading list on every parse.
-  const body = await marked.parse(source);
+  // No await between this parse and renderToc, and that is the fix rather than
+  // a tidy-up.
+  //
+  // renderToc reads marked-gfm-heading-id's heading list, which lives at module
+  // scope, and gfmHeadingId's preprocess hook clears it at the start of every
+  // parse. So a body is only safely paired with its own table of contents while
+  // nothing else parses in between - and `await` was exactly that gap. parse is
+  // synchronous with this plugin set (hence `async: false` above), so the await
+  // bought nothing but a microtask yield, and any other render landing in it left
+  // this response holding the other file's headings.
+  //
+  // It was invisible before per-file URLs, because the server only ever rendered
+  // one file and two concurrent renders read the same headings. Rendering
+  // different files at once is the entire point of those URLs, so it is not
+  // invisible now.
+  //
+  // Reading the list sooner would not help: the clobber happens during the yield,
+  // not after it. Atomicity is the property being bought, and the only way to
+  // have it is for there to be no yield at all. renderPage stays async for the
+  // file read above, which is a real await and harmless - it is before the parse.
+  const body = marked.parse(source);
+  // A future plugin that makes parse asynchronous again would otherwise render
+  // "[object Promise]" into the page and quietly bring the interleaving back.
+  // Better to stop here and say which invariant broke.
+  if (typeof body !== "string") {
+    throw new Error(
+      "marked.parse returned a promise: renderToc can no longer be trusted to " +
+        "match the body it is paired with",
+    );
+  }
   return htmlResponse(nonce, basename(file), file, body, events, renderToc());
 }
 

--- a/.config/herdr/mdpreview-server/server.ts
+++ b/.config/herdr/mdpreview-server/server.ts
@@ -4,6 +4,17 @@
 // rendered here in Bun. Mermaid is the one thing that needs a DOM, so its
 // fences are passed through as <pre class="mermaid"> and drawn by mermaid.js
 // in the browser that displays the page.
+//
+// Which file a page shows is carried in its own URL - /?file=<path> - and not in
+// a variable here. That is the whole difference between this and the version
+// before it. With one currentFile every surface pointed at this server shared
+// it: opening B navigated the pane that was showing A, a herdr pane and a
+// desktop tab could not hold different files, and neither could two tabs. The
+// path in the query makes each page independent, and the reload channel is keyed
+// the same way so that saving a file only wakes the pages actually showing it.
+//
+// A bare / still renders the last file opened as the current one, so a page from
+// before this change, or a URL someone kept, still resolves to something.
 
 import { realpathSync, statSync, watch, type FSWatcher } from "node:fs";
 import { basename, dirname, extname, resolve } from "node:path";
@@ -17,7 +28,10 @@ import { getHeadingList, gfmHeadingId } from "marked-gfm-heading-id";
 // otherwise become Number("") === 0 and make Bun listen on a random port, while
 // bin/mdpreview's ${MDPREVIEW_PORT:-43128} still talks to 43128.
 const PORT = Number(process.env.MDPREVIEW_PORT) || 43128;
-const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown"]);
+// .mdown is here because bin/mdpreview's own classifier takes it as a markdown
+// path. Without it the command advertised a spelling this then refused, and the
+// refusal named the file rather than the mismatch that caused it.
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown", ".mdown"]);
 // The names the page is ever legitimately reached under. A DNS rebinding attack
 // resolves the attacker's own hostname to 127.0.0.1, and the Host header is what
 // gives that away.
@@ -53,11 +67,52 @@ const marked = new Marked(
   },
 );
 
-let currentFile: string | null = null;
-let watchers: FSWatcher[] = [];
-let watchedState = "";
-let reloadTimer: ReturnType<typeof setTimeout> | null = null;
-const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
+// Every path /open has accepted, and the only paths ?file= will render.
+//
+// This is the load-bearing half of putting the path in the URL. Without it the
+// query would be an instruction to read and serve any file on the machine to
+// whoever asked - and whoever asked includes every page already open in the
+// user's browser, which can point an iframe or a window at 127.0.0.1 without
+// being able to read the result but perfectly able to make the read happen. The
+// markdown-extension check narrows that; it does not close it. Registration
+// does: a path arrives here only by way of /open, which nothing but local
+// tooling can reach - see the Origin refusal there.
+//
+// It only grows. A preview server is a per-session thing and the set is a
+// handful of strings; evicting would mean deciding that a path someone may still
+// have a tab on is no longer allowed to render, which is the worse failure.
+const registered = new Set<string>();
+
+// The file a bare / renders, and the file the empty-keyed reload channel
+// follows. Only /open with current !== false moves it - see registerFile for why
+// --browser deliberately does not.
+let lastOpened: string | null = null;
+// The most recent /open of any kind, current or not. bin/mdpreview's --browser
+// resumes from this: it never sets lastOpened, so without a second field a
+// server that had only ever served --browser would report nothing being
+// previewed while holding a tab's worth of it.
+let lastRegistered: string | null = null;
+
+// One reload channel per path, plus one under the empty key that follows
+// whatever lastOpened is. That is where a page reached through a bare / sits,
+// since the file behind that URL moves and the URL itself says nothing about
+// which file it is.
+//
+// The watchers belong to the channel rather than to the server, and that is what
+// makes them refcounted: a path is watched while at least one page is looking at
+// it and not otherwise. Watching every path ever opened would hold an fs watch
+// per preview for the life of the process, and a channel with nobody connected
+// has nothing to deliver a reload to anyway.
+interface Channel {
+  // The surface each client declared, so that /viewers can answer for browser
+  // tabs without counting herdr panes. Both are Chrome speaking HTTP; nothing
+  // about the connection itself tells them apart.
+  clients: Map<ReadableStreamDefaultController<Uint8Array>, string>;
+  watchers: FSWatcher[];
+  watchedState: string;
+  reloadTimer: ReturnType<typeof setTimeout> | null;
+}
+const channels = new Map<string, Channel>();
 
 // Callers drop the result into text nodes and double-quoted attributes, so &#39;
 // buys nothing today -- it is there so a future single-quoted attribute cannot
@@ -71,13 +126,23 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
-function broadcastReload(): void {
+// The file a channel key stands for. Every key is its own path except the empty
+// one, which means "whatever is current" and therefore moves.
+function channelPath(key: string): string | null {
+  return key === "" ? lastOpened : key;
+}
+
+function broadcastReload(key: string): void {
+  const channel = channels.get(key);
+  if (!channel) {
+    return;
+  }
   const payload = new TextEncoder().encode("data: reload\n\n");
-  for (const client of clients) {
+  for (const client of channel.clients.keys()) {
     try {
       client.enqueue(payload);
     } catch {
-      clients.delete(client);
+      channel.clients.delete(client);
     }
   }
 }
@@ -105,6 +170,17 @@ function realPath(path: string): string {
   }
 }
 
+function stopWatching(channel: Channel): void {
+  for (const open of channel.watchers) {
+    open.close();
+  }
+  channel.watchers = [];
+  if (channel.reloadTimer) {
+    clearTimeout(channel.reloadTimer);
+    channel.reloadTimer = null;
+  }
+}
+
 // Watch the containing directory rather than the file: editors that save by
 // writing a temp file and renaming it over the original break a file watch.
 // macOS reports only the source name for that rename, so the watched file's own
@@ -119,12 +195,25 @@ function realPath(path: string): string {
 // Directories are keyed by their resolved path, so the ordinary case where the
 // two differ only in a parent symlink (/tmp vs /private/tmp) collapses back to
 // the single watch it has always been.
-function watchFile(file: string): void {
-  for (const open of watchers) {
-    open.close();
+//
+// Per channel rather than per server now, which is what keeps a save to one
+// preview's file from reloading another's page. The state and the timer moved
+// onto the channel with it for the same reason: two files being edited at once
+// would otherwise share one debounce and one fingerprint, and the second event
+// would cancel the first file's pending reload.
+function startWatching(key: string): void {
+  const channel = channels.get(key);
+  if (!channel) {
+    return;
   }
-  watchers = [];
-  watchedState = fileState(file);
+  stopWatching(channel);
+  const file = channelPath(key);
+  // The empty-keyed channel before anything has been opened: nothing to watch
+  // yet, and retargetCurrent comes back here once there is.
+  if (!file) {
+    return;
+  }
+  channel.watchedState = fileState(file);
   const names = new Map<string, Set<string>>();
   for (const path of [file, realPath(file)]) {
     const dir = realPath(dirname(path));
@@ -133,26 +222,108 @@ function watchFile(file: string): void {
     names.set(dir, known);
   }
   for (const [dir, known] of names) {
-    watchers.push(
+    channel.watchers.push(
       watch(dir, (_event, changed) => {
         // Fingerprint the path as opened, not the resolved one: statSync follows
         // the link, so one comparison covers both an edit to the real file and a
         // link repointed at a different file.
         const state = fileState(file);
-        if (!known.has(changed ?? "") && state === watchedState) {
+        if (!known.has(changed ?? "") && state === channel.watchedState) {
           return;
         }
-        watchedState = state;
-        if (reloadTimer) {
-          clearTimeout(reloadTimer);
+        channel.watchedState = state;
+        if (channel.reloadTimer) {
+          clearTimeout(channel.reloadTimer);
         }
-        reloadTimer = setTimeout(broadcastReload, 50);
+        channel.reloadTimer = setTimeout(() => broadcastReload(key), 50);
       }),
     );
   }
 }
 
-async function setCurrentFile(rawPath: string): Promise<string> {
+function subscribe(
+  key: string,
+  surface: string,
+  client: ReadableStreamDefaultController<Uint8Array>,
+): void {
+  let channel = channels.get(key);
+  if (!channel) {
+    channel = { clients: new Map(), watchers: [], watchedState: "", reloadTimer: null };
+    channels.set(key, channel);
+  }
+  const first = channel.clients.size === 0;
+  channel.clients.set(client, surface);
+  if (first) {
+    startWatching(key);
+  }
+}
+
+function unsubscribe(key: string, client: ReadableStreamDefaultController<Uint8Array>): void {
+  const channel = channels.get(key);
+  if (!channel) {
+    return;
+  }
+  channel.clients.delete(client);
+  if (channel.clients.size > 0) {
+    return;
+  }
+  // Last one out closes the watch and takes the channel with it. The
+  // empty-keyed channel is no exception: recreating it costs a map insert, and
+  // leaving it behind would leave an fs watch on a file nobody is showing.
+  stopWatching(channel);
+  channels.delete(key);
+}
+
+// Browser tabs currently showing a path, as distinct from herdr panes.
+// bin/mdpreview asks before opening a tab, so that running --browser twice does
+// not stack two tabs on the same preview.
+//
+// Panes are excluded on purpose. A pane already showing the file is not a reason
+// to refuse someone who asked for a browser tab, and counting it would make the
+// command report a tab that does not exist. Nothing about the connection says
+// which is which, so each page declares it in its own /events URL, put there by
+// whichever half of bin/mdpreview opened it.
+//
+// A page only counts while its EventSource is connected, so a background tab
+// that Chrome has discarded or frozen reads as absent and a second tab opens.
+// That is the failure worth having: the other direction refuses to open a tab
+// because of one the user can no longer see.
+function tabsShowing(key: string): number {
+  const channel = channels.get(key);
+  if (!channel) {
+    return 0;
+  }
+  let count = 0;
+  for (const surface of channel.clients.values()) {
+    if (surface === "tab") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+// Points the follow-the-current-file channel at whatever lastOpened has become
+// and tells the pages sitting in it to reload: their URL has not changed but the
+// file behind it has.
+function retargetCurrent(): void {
+  if (!channels.has("")) {
+    return;
+  }
+  startWatching("");
+  broadcastReload("");
+}
+
+// Registers a path and, unless told otherwise, makes it the current one.
+//
+// The split exists for --browser, and it is not visible from either side alone.
+// A browser preview has to be able to open B without disturbing a herdr pane
+// showing A. Panes navigate to their own ?file= URL, so lastOpened does not
+// reach them - but a page on a bare /, which is any page from before this change
+// and any URL a person typed, follows lastOpened and would be dragged onto B.
+// Registering without making it current gives --browser exactly what it needs, a
+// path that ?file= will serve and a channel to reload, and none of what it does
+// not.
+async function registerFile(rawPath: string, makeCurrent: boolean): Promise<string> {
   const file = resolve(rawPath);
   if (!MARKDOWN_EXTENSIONS.has(extname(file).toLowerCase())) {
     throw new Error(`not a markdown file: ${file}`);
@@ -160,9 +331,55 @@ async function setCurrentFile(rawPath: string): Promise<string> {
   if (!(await Bun.file(file).exists())) {
     throw new Error(`no such file: ${file}`);
   }
-  currentFile = file;
-  watchFile(file);
+  registered.add(file);
+  lastRegistered = file;
+  if (makeCurrent) {
+    lastOpened = file;
+  }
   return file;
+}
+
+// The path a request is asking for, or the sentinel for "whatever is current".
+//
+// A query naming a path this server was never told about is refused here, before
+// anything resolves or reads it, which is the whole point of the registry. The
+// refusal is a 404 rather than a 403 so that it says the same thing about a path
+// that exists on disk and one that does not.
+type Target = { ok: true; key: string; file: string | null } | { ok: false };
+
+function targetFor(url: URL): Target {
+  // searchParams has already percent-decoded, which is what bin/mdpreview's
+  // @uri encoding on the way out is for: paths hold spaces, & and # as readily
+  // as anything else, and an unencoded # would cut the path in half before it
+  // ever reached the server.
+  const raw = url.searchParams.get("file");
+  if (raw === null) {
+    return { ok: true, key: "", file: lastOpened };
+  }
+  const file = resolve(raw);
+  if (!registered.has(file)) {
+    return { ok: false };
+  }
+  return { ok: true, key: file, file };
+}
+
+// Only two surfaces exist, and an unknown one has to be read as one of them. A
+// tab is the safe reading: miscounting a pane as a tab at worst suppresses one
+// tab someone asked for, while the reverse stacks tabs on every run.
+function surfaceFor(url: URL): string {
+  return url.searchParams.get("surface") === "pane" ? "pane" : "tab";
+}
+
+// The /events URL for a page, built here rather than in the page's own script so
+// that the path never has to be re-derived from location.search by hand.
+function eventsUrl(url: URL): string {
+  const params = new URLSearchParams();
+  const raw = url.searchParams.get("file");
+  if (raw !== null) {
+    params.set("file", raw);
+  }
+  params.set("surface", surfaceFor(url));
+  return `/events?${params.toString()}`;
 }
 
 function renderToc(): string {
@@ -197,7 +414,7 @@ function contentSecurityPolicy(nonce: string): string {
     "style-src 'self' 'unsafe-inline'",
     // README badges are remote, and github-markdown-css inlines data: SVGs.
     "img-src 'self' data: https:",
-    // new EventSource("/events").
+    // new EventSource("/events?file=...&surface=...").
     "connect-src 'self'",
     "object-src 'none'",
     "base-uri 'none'",
@@ -209,9 +426,10 @@ function htmlResponse(
   title: string,
   path: string,
   body: string,
+  events: string,
   toc = "",
 ): Response {
-  return new Response(shell(nonce, title, path, body, toc), {
+  return new Response(shell(nonce, title, path, body, events, toc), {
     headers: {
       "content-type": "text/html; charset=utf-8",
       "content-security-policy": contentSecurityPolicy(nonce),
@@ -219,32 +437,44 @@ function htmlResponse(
   });
 }
 
-async function renderPage(): Promise<Response> {
+async function renderPage(url: URL): Promise<Response> {
   const nonce = newNonce();
-  if (!currentFile) {
-    return htmlResponse(nonce, "mdpreview", "", "<p>No file selected.</p>");
+  const target = targetFor(url);
+  if (!target.ok) {
+    return new Response("not found", { status: 404 });
+  }
+  const events = eventsUrl(url);
+  const file = target.file;
+  if (!file) {
+    return htmlResponse(nonce, "mdpreview", "", "<p>No file selected.</p>", events);
   }
   let source: string;
   try {
-    source = await Bun.file(currentFile).text();
+    source = await Bun.file(file).text();
   } catch (error) {
     // An editor or `git checkout` can leave the file missing for a moment. Serve
     // the shell anyway so the page keeps its /events listener and recovers on the
     // next change, instead of turning into Bun's 500 page and going deaf.
     const message = error instanceof Error ? error.message : String(error);
-    return htmlResponse(
-      nonce,
-      basename(currentFile),
-      currentFile,
-      `<p>${escapeHtml(message)}</p>`,
-    );
+    return htmlResponse(nonce, basename(file), file, `<p>${escapeHtml(message)}</p>`, events);
   }
   // gfmHeadingId's preprocess hook clears the heading list on every parse.
   const body = await marked.parse(source);
-  return htmlResponse(nonce, basename(currentFile), currentFile, body, renderToc());
+  return htmlResponse(nonce, basename(file), file, body, events, renderToc());
 }
 
-function shell(nonce: string, title: string, path: string, body: string, toc = ""): string {
+function shell(
+  nonce: string,
+  title: string,
+  path: string,
+  body: string,
+  events: string,
+  toc = "",
+): string {
+  // JSON.stringify makes the URL a JS string literal; < is escaped on top of
+  // that because JSON.stringify leaves it alone, and a path spelling a closing
+  // script tag would otherwise end the block early.
+  const eventsLiteral = JSON.stringify(events).replaceAll("<", "\\u003c");
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -291,7 +521,7 @@ function shell(nonce: string, title: string, path: string, body: string, toc = "
   const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   mermaid.initialize({ startOnLoad: false, theme: dark ? "dark" : "default" });
   mermaid.run({ querySelector: "pre.mermaid" });
-  new EventSource("/events").onmessage = () => location.reload();
+  new EventSource(${eventsLiteral}).onmessage = () => location.reload();
 </script>
 </body>
 </html>`;
@@ -320,14 +550,18 @@ const server = Bun.serve({
   port: PORT,
   idleTimeout: 0,
   async fetch(request) {
-    const { pathname } = new URL(request.url);
+    const url = new URL(request.url);
+    const { pathname } = url;
 
     if (!ALLOWED_HOSTS.has(request.headers.get("host") ?? "")) {
       return new Response("forbidden", { status: 403 });
     }
 
     if (pathname === "/health") {
-      return Response.json({ ok: true, file: currentFile });
+      // `file` keeps its old meaning, the file a bare / renders, because an
+      // older bin/mdpreview reads exactly that field. `recent` is the addition,
+      // and its absence is how a newer script recognises an older server.
+      return Response.json({ ok: true, file: lastOpened, recent: lastRegistered });
     }
 
     if (pathname === "/open" && request.method === "POST") {
@@ -336,13 +570,24 @@ const server = Bun.serve({
       if (request.headers.get("origin") !== null) {
         return new Response("forbidden", { status: 403 });
       }
-      const { path } = (await request.json()) as { path?: string };
+      const { path, current } = (await request.json()) as {
+        path?: string;
+        current?: boolean;
+      };
       if (!path) {
         return Response.json({ ok: false, error: "missing path" }, { status: 400 });
       }
       try {
-        const file = await setCurrentFile(path);
-        broadcastReload();
+        // Absent means current, so a script from before this change still works.
+        const makeCurrent = current !== false;
+        const file = await registerFile(path, makeCurrent);
+        // The file's own channel first, then the follow-current one if this
+        // moved it. A page in both at once would be an odd thing to arrange and
+        // the worst it costs is a second reload of a page that just reloaded.
+        broadcastReload(file);
+        if (makeCurrent) {
+          retargetCurrent();
+        }
         return Response.json({ ok: true, file });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -350,7 +595,34 @@ const server = Bun.serve({
       }
     }
 
+    if (pathname === "/viewers") {
+      // Not for pages to call. It answers a question about what the user has
+      // open, and no page has a use for the answer - bin/mdpreview is what asks,
+      // before deciding whether to open a tab. A same-origin GET carries no
+      // Origin, so this turns away a cross-origin caller rather than our own
+      // page; the cross-origin one is the caller it is here to turn away.
+      if (request.headers.get("origin") !== null) {
+        return new Response("forbidden", { status: 403 });
+      }
+      const target = targetFor(url);
+      // An unregistered path has no channel and therefore no viewers. Answering
+      // 0 rather than 404 keeps this from doubling as a way to ask which paths
+      // are registered.
+      const count = target.ok ? tabsShowing(target.key) : 0;
+      return Response.json({ ok: true, count });
+    }
+
     if (pathname === "/events") {
+      // Reachable from the page, unlike /open and /viewers: this is the one
+      // endpoint the preview itself has to call, and an EventSource is how it
+      // calls it. The registry check is what keeps that from being a way to ask
+      // the server to watch an arbitrary path and report when it changes.
+      const target = targetFor(url);
+      if (!target.ok) {
+        return new Response("not found", { status: 404 });
+      }
+      const key = target.key;
+      const surface = surfaceFor(url);
       // cancel() is handed the cancellation reason, not the controller, so hold
       // our own reference to drop the client when the page goes away.
       let client: ReadableStreamDefaultController<Uint8Array> | null = null;
@@ -358,11 +630,11 @@ const server = Bun.serve({
         new ReadableStream({
           start(controller) {
             client = controller;
-            clients.add(controller);
+            subscribe(key, surface, controller);
           },
           cancel() {
             if (client) {
-              clients.delete(client);
+              unsubscribe(key, client);
             }
           },
         }),
@@ -381,7 +653,7 @@ const server = Bun.serve({
     }
 
     if (pathname === "/") {
-      return renderPage();
+      return renderPage(url);
     }
 
     return new Response("not found", { status: 404 });
@@ -390,7 +662,7 @@ const server = Bun.serve({
 
 const initial = process.argv[2];
 if (initial) {
-  await setCurrentFile(initial);
+  await registerFile(initial, true);
 }
 
 console.log(`mdpreview-server listening on http://127.0.0.1:${server.port}`);

--- a/README.md
+++ b/README.md
@@ -111,12 +111,22 @@ same one either way.
 
 `--browser` asks for that tab outright, and works inside a herdr session too:
 it is how a preview goes to the browser that is already open rather than into a
-pane. With no file argument it reuses whatever the server is currently holding,
-the way `--reset` does, and says so if nothing is. Two things are worth knowing
-before leaning on it. The server still tracks a single current file, so a tab
-and a preview pane share one preview: previewing a second file navigates both.
-And `open` starts a tab rather than finding an existing one, so running
-`--browser` twice can leave two tabs on the same preview - close the spare.
+pane. It needs `open` (macOS) or `xdg-open` (Linux) and refuses outright with
+neither - the one way this can fail that the pane path has no equivalent for. It
+also takes focus, unlike a pane: a pane is already on screen in the tab being
+looked at, whereas asking for a browser tab is asking to be shown one.
+
+With no file argument it reuses whatever the server is currently holding, the way
+`--reset` does, and says so if nothing is. Handing the file back over broadcasts
+a reload, so a preview already open on a long document scrolls back to the top.
+
+Three things are worth knowing before leaning on it. The server still tracks a
+single current file, so a tab and a preview pane share one preview: previewing a
+second file navigates both. `open` starts a tab rather than finding an existing
+one, so running `--browser` twice leaves two tabs on the same preview - close the
+spare. And a preview in a tab cannot be driven: `mdpreview text` and the rest of
+the passthrough need a view, so inside a herdr session they report having no
+preview in this tab even while a `--browser` tab is open on one.
 
 With two or more browser panes open, herdr-browser cannot pick a target for
 itself (409), so which view to aim at has to be named. Working that out is

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ and so on, for driving from Bash in Claude Code):
 
 # mdpreview
 
-Previews markdown in a herdr-browser pane. Embedded mermaid renders too, and
-saving the file reloads the page. Nothing goes out to the network - mermaid.js
-and highlight.js are both served locally.
+Previews markdown in a herdr-browser pane, or in an ordinary desktop browser
+tab. Embedded mermaid renders too, and saving the file reloads the page. Nothing
+goes out to the network - mermaid.js and highlight.js are both served locally.
 
 Markdown, syntax highlighting, GitHub alerts and the table of contents are
 rendered on the Bun side; only mermaid, which needs a DOM, is drawn in the
@@ -93,6 +93,8 @@ browser.
 Usage (the port is 43128 by default; `MDPREVIEW_PORT` overrides it):
 
 	mdpreview README.md
+	mdpreview --browser README.md
+	mdpreview --browser     # the same, for whatever is already being previewed
 	mdpreview text          # any herdr-browser command, aimed at this tab's preview
 	mdpreview console
 	mdpreview --screen      # the viewer's own errors, as written onto the pane
@@ -102,15 +104,29 @@ Usage (the port is 43128 by default; `MDPREVIEW_PORT` overrides it):
 A herdr-browser pane in the same tab is reused; a tab without one gets a fresh
 pane split off to the right, without taking focus. A view in another tab is not a
 candidate for reuse - nobody in this tab can see it. Outside herdr (no
-HERDR_TAB_ID / HERDR_PANE_ID) there is no tab to scope to, so any existing view
-is used and, failing that, the focused pane is split.
+HERDR_TAB_ID / HERDR_PANE_ID) there is no tab to scope to and no pane to split
+from, so a file argument goes to the desktop browser instead. The render server
+has no herdr in it - it is plain HTTP on the loopback port - so the page is the
+same one either way.
+
+`--browser` asks for that tab outright, and works inside a herdr session too:
+it is how a preview goes to the browser that is already open rather than into a
+pane. With no file argument it reuses whatever the server is currently holding,
+the way `--reset` does, and says so if nothing is. Two things are worth knowing
+before leaning on it. The server still tracks a single current file, so a tab
+and a preview pane share one preview: previewing a second file navigates both.
+And `open` starts a tab rather than finding an existing one, so running
+`--browser` twice can leave two tabs on the same preview - close the spare.
 
 With two or more browser panes open, herdr-browser cannot pick a target for
 itself (409), so which view to aim at has to be named. Working that out is
 mdpreview's job: `mdpreview <herdr-browser command>` names this tab's view and
 then calls herdr-browser. Nothing on the calling side has to read the pane or
-view list. `--view` (view id) and `--pane` (pane id) are still there for a
-command that wants an id in the environment.
+view list. Those commands reach the page over CDP, which gets to a herdr-browser
+pane and to nothing else - a desktop tab has no view to attach to - so outside
+herdr they say so rather than answering about a Chrome in some other tab.
+`--view` (view id) and `--pane` (pane id) are still there for a command that
+wants an id in the environment.
 
 The render server lives in `.config/herdr/mdpreview-server` (bun) and logs to
 `${TMPDIR}/mdpreview-server.log`. It sits at a different layer from the command

--- a/README.md
+++ b/README.md
@@ -105,14 +105,17 @@ A herdr-browser pane in the same tab is reused; a tab without one gets a fresh
 pane split off to the right, without taking focus. A view in another tab is not a
 candidate for reuse - nobody in this tab can see it. Outside herdr (no
 HERDR_TAB_ID / HERDR_PANE_ID) there is no tab to scope to and no pane to split
-from, so a file argument goes to the desktop browser instead. The render server
-has no herdr in it - it is plain HTTP on the loopback port - so the page is the
-same one either way.
+from, so a file argument goes to the desktop browser instead, taking focus with
+it - the same tab `--browser` would open, on a path that never asked for one. The
+render server has no herdr in it - it is plain HTTP on the loopback port - so the
+page is the same one either way.
 
 `--browser` asks for that tab outright, and works inside a herdr session too:
 it is how a preview goes to the browser that is already open rather than into a
 pane. It needs `open` (macOS) or `xdg-open` (Linux) and refuses outright with
-neither - the one way this can fail that the pane path has no equivalent for. It
+neither - the plainest way this can fail that the pane path has no equivalent
+for; an opener that is installed but cannot reach a display (`xdg-open` with no
+`DISPLAY`, say) fails later, and reports whatever it has to say for itself. It
 also takes focus, unlike a pane: a pane is already on screen in the tab being
 looked at, whereas asking for a browser tab is asking to be shown one.
 
@@ -136,7 +139,10 @@ view list. Those commands reach the page over CDP, which gets to a herdr-browser
 pane and to nothing else - a desktop tab has no view to attach to - so outside
 herdr they say so rather than answering about a Chrome in some other tab.
 `--view` (view id) and `--pane` (pane id) are still there for a command that
-wants an id in the environment.
+wants an id in the environment. Outside herdr `--view` still answers with
+whatever view the daemon has, since asking for an id by name is asking for that;
+what it cannot do is produce one for a `--browser` tab, which has no view id, so
+with no pane open anywhere it refuses instead.
 
 The render server lives in `.config/herdr/mdpreview-server` (bun) and logs to
 `${TMPDIR}/mdpreview-server.log`. It sits at a different layer from the command

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ goes out to the network - mermaid.js and highlight.js are both served locally.
 
 Markdown, syntax highlighting, GitHub alerts and the table of contents are
 rendered on the Bun side; only mermaid, which needs a DOM, is drawn in the
-browser.
+browser. `.md`, `.markdown` and `.mdown` all count as markdown.
 
 	cd ~/src/github.com/motchang/dotfiles/.config/herdr/mdpreview-server && bun install
 
@@ -94,7 +94,7 @@ Usage (the port is 43128 by default; `MDPREVIEW_PORT` overrides it):
 
 	mdpreview README.md
 	mdpreview --browser README.md
-	mdpreview --browser     # the same, for whatever is already being previewed
+	mdpreview --browser     # the same, for the file most recently previewed
 	mdpreview text          # any herdr-browser command, aimed at this tab's preview
 	mdpreview console
 	mdpreview --screen      # the viewer's own errors, as written onto the pane
@@ -119,17 +119,34 @@ for; an opener that is installed but cannot reach a display (`xdg-open` with no
 also takes focus, unlike a pane: a pane is already on screen in the tab being
 looked at, whereas asking for a browser tab is asking to be shown one.
 
-With no file argument it reuses whatever the server is currently holding, the way
-`--reset` does, and says so if nothing is. Handing the file back over broadcasts
-a reload, so a preview already open on a long document scrolls back to the top.
+With no file argument it reuses the most recent file any surface was pointed at,
+and says so if there is none. `--reset` with no argument comes back to the file
+the pane modes last opened instead, which is the one a pane is actually showing.
+Either way, handing the file back over broadcasts a reload, so a page already
+open on a long document scrolls back to the top.
 
-Three things are worth knowing before leaning on it. The server still tracks a
-single current file, so a tab and a preview pane share one preview: previewing a
-second file navigates both. `open` starts a tab rather than finding an existing
-one, so running `--browser` twice leaves two tabs on the same preview - close the
-spare. And a preview in a tab cannot be driven: `mdpreview text` and the rest of
-the passthrough need a view, so inside a herdr session they report having no
-preview in this tab even while a `--browser` tab is open on one.
+Previews are independent of each other. Each page carries its own file in its
+URL - `/?file=<path>` - so a pane in this tab, a pane in another and any number
+of browser tabs each hold a different file, and saving one reloads only the pages
+showing that one. `--browser B.md` while a pane shows `A.md` leaves that pane on
+`A.md`. Only a bare `/`, which is what a hand-typed URL and a page from before
+this gets, follows whichever file was opened last.
+
+Running `--browser` twice does not stack tabs: the server knows whether a live
+page is already showing the file and the second run reloads that instead of
+opening another. It knows by counting connected reload streams, so a tab Chrome
+has discarded or frozen in the background reads as gone and a second tab opens -
+an occasional spare tab rather than a refusal to show a preview that is no longer
+on screen. Panes are not counted; a pane on the file is no reason to withhold a
+tab from someone who asked for one.
+
+What a tab still cannot do is be driven. `mdpreview text` and the rest of the
+passthrough need a view, so inside a herdr session they report having no preview
+in this tab even while a `--browser` tab is open on one.
+
+`?file=` only serves paths that were registered by previewing them. A markdown
+file sitting on disk that mdpreview was never pointed at comes back 404, and so
+does anything else - the query is not a way to ask this server to read a file.
 
 With two or more browser panes open, herdr-browser cannot pick a target for
 itself (409), so which view to aim at has to be named. Working that out is

--- a/README.md
+++ b/README.md
@@ -130,15 +130,21 @@ URL - `/?file=<path>` - so a pane in this tab, a pane in another and any number
 of browser tabs each hold a different file, and saving one reloads only the pages
 showing that one. `--browser B.md` while a pane shows `A.md` leaves that pane on
 `A.md`. Only a bare `/`, which is what a hand-typed URL and a page from before
-this gets, follows whichever file was opened last.
+this gets, follows a file it was not told about - and it follows the one the pane
+modes last opened, not the most recent of all: `--browser B.md` leaves a bare-`/`
+page on `A.md` too, which is the same distinction `--reset` and `--browser` draw
+between them above.
 
 Running `--browser` twice does not stack tabs: the server knows whether a live
 page is already showing the file and the second run reloads that instead of
-opening another. It knows by counting connected reload streams, so a tab Chrome
-has discarded or frozen in the background reads as gone and a second tab opens -
-an occasional spare tab rather than a refusal to show a preview that is no longer
-on screen. Panes are not counted; a pane on the file is no reason to withhold a
-tab from someone who asked for one.
+opening another. It knows by counting connected reload streams, which leaves two
+windows where a spare tab still appears. One is a tab Chrome has discarded or
+frozen in the background, which reads as gone. The other is two runs close
+enough together that the first tab has not finished loading and connecting its
+stream - the easier of the two to hit, and no heuristic is going to tell that
+apart from a tab that never opened. A spare tab is the better failure than
+refusing to show a preview that is not on screen. Panes are not counted either;
+a pane on the file is no reason to withhold a tab from someone who asked for one.
 
 What a tab still cannot do is be driven. `mdpreview text` and the rest of the
 passthrough need a view, so inside a herdr session they report having no preview


### PR DESCRIPTION
`mdpreview` could only put a preview in a herdr-browser pane. Now it can put one
in the desktop browser as well, and previews no longer share a single file.

    mdpreview --browser file.md   # a desktop browser tab, from inside a session too
    mdpreview file.md             # outside herdr, this now goes to the browser

## Why this splits the way it does

The render server never had any herdr in it — it serves plain HTTP on the
loopback port — so the page it renders is already the page an ordinary browser
tab would show. All the herdr coupling was in `bin/mdpreview`'s pane and view
resolution. The first commit is only the shell script: a new entry point onto a
server that already worked. The fourth is the server change that stops every
surface from sharing one file.

Outside a herdr session the old file path reached for any view the daemon had
and split a pane next to whatever had focus, and from a plain terminal it never
got that far — it died reading the view list. Both README and the skill doc
described that path as not useful. It goes to the browser now.

## What each commit does

| | |
|---|---|
| `f0f59cc` | `--browser`, the opener, and the unscoped fallback. Shell only. |
| `bcedebd` | Review: messages that sent a caller round the same failure twice, or claimed something the code does not do. `set_file` reports the server's reason instead of `curl: (22)`. |
| `ce69dcb` | Review: `--reset FILE` closed the tab's panes before `set_file` could refuse the argument, so a rejected `.txt` destroyed a working preview. |
| `bc392f9` | The file moves into the URL. Per-path reload channels, a registry, `--browser` no longer dragging a pane along, no more duplicate tabs, `.mdown`. |
| `cc3c6b7` | Review: a vanished directory made `fs.watch` throw out of `/events`, wedging the preview and leaving a client nothing could reap. |

## The registry is load-bearing

`?file=` serves only paths that arrived through `/open`. Without that the query
would be an instruction to read any file on the machine on behalf of whoever
asked — and whoever asked includes every page already open in the user's
browser, which can point an iframe at `127.0.0.1` without being able to read the
reply but perfectly able to cause the read. The markdown-extension check narrows
that; it does not close it. `/events` is registry-checked for the same reason:
otherwise it is a way to have the server watch an arbitrary path and report when
it changed.

The directory watching was **moved**, not rewritten — the temp-file rename, the
symlinked target's own directory, and the stat fingerprint that keeps an
unrelated save in the same directory quiet are all still there. The fingerprint
and the debounce timer moved onto the channel with it, or two files edited at
once would share one of each and the second event would cancel the first file's
pending reload.

## Verified

Endpoint boundaries: a registered path renders; an unregistered but real `.md`
is 404 with its content absent from the body; so are `/etc/passwd` and a `../`
escape; `/events` matches in both directions. `Origin` is refused on `/open` and
`/viewers` and allowed on `/events`, which the page has to call. A spoofed
`Host` is 403. `/viewers` answers `count: 0` rather than 404 for an unregistered
path, so it cannot double as a way to ask what is registered. The CSP arrives
complete with a fresh nonce and no `unsafe-inline` in `script-src`.

Behaviour: a pane on `alpha.md` is untouched by `--browser beta.md` — same URL,
`mdpreview text` still returns Alpha. Saving `alpha.md` reloads only alpha's
stream; saving an unrelated `.md` in the same directory reloads neither.
Duplicate-tab suppression fires while a tab is connected and releases when it
goes. `find_opener` picks `open` on Darwin and `xdg-open` elsewhere, keeps the
other as a fallback, and refuses before the file is handed over when neither
exists. A vanished directory leaves the page on a 200 shell with `/events`
answering and no phantom viewer, and re-registering re-arms the watch.

## Known limits

- Two `--browser` runs close enough together that the first tab has not
  connected its stream still stack. The count is live connections, and nothing
  distinguishes that window from a tab that never opened.
- A background tab Chrome has discarded or frozen reads as absent for the same
  reason, so an occasional extra tab. Reasoned about and documented, not
  reproduced — Chrome will not discard a tab on demand.
- `--browser` takes focus, unlike a pane. Deliberate: asking for a browser tab is
  asking to be shown one. The unscoped fallback inherits it without having asked.
- The `xdg-open` branch was exercised through a `uname` stub, not on Linux.
- `--reset`'s daemon stage and `--screen` are untouched and were never reached.

The skill doc lives in `motchang/.claude` and is updated there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
